### PR TITLE
WIP - Add workload version to juju status

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,7 +8,6 @@ description: |
   A charm for the matrix synapse chat server.
   Synapse is a drop in replacement for other chat servers like Mattermost and Slack.
   This charm is useful if you want to spin up your own chat instance.
-docs: ""
 issues: https://github.com/canonical/synapse-operator/issues
 maintainers:
   - launchpad.net/~canonical-is-devops

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ from ops.charm import ActionEvent
 from ops.main import main
 
 import actions
+import synapse
 from charm_state import CharmConfigInvalidError, CharmState
 from constants import SYNAPSE_CONTAINER_NAME, SYNAPSE_PORT
 from database_observer import DatabaseObserver
@@ -93,6 +94,11 @@ class SynapseCharm(ops.CharmBase):
         Args:
             event: Event triggering after pebble is ready.
         """
+        try:
+            synapse_version = synapse.get_version()
+            self.unit.set_workload_version(synapse_version)
+        except synapse.APIError as exc:
+            logger.debug("Cannot set workload version at this time: %s", exc)
         self.change_config(event)
 
     def _on_reset_instance_action(self, event: ActionEvent) -> None:

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -4,7 +4,7 @@
 """Synapse package is used to interact with Synapse instance."""
 
 # Exporting methods to be used for another modules
-from .api import APIError, register_user  # noqa: F401
+from .api import APIError, get_version, register_user  # noqa: F401
 from .workload import (  # noqa: F401
     ExecResult,
     WorkloadError,

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -77,7 +77,7 @@ def check_ready() -> typing.Dict:
     check = Check(CHECK_READY_NAME)
     check.override = "replace"
     check.level = "ready"
-    check.tcp = {"port": SYNAPSE_PORT}
+    check.http = {"url": f"http://localhost:{SYNAPSE_PORT}/_synapse/admin/v1/server_version"}
     # _CheckDict cannot be imported
     return check.to_dict()  # type: ignore
 

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -87,9 +87,9 @@ def test_generate_mac():
 @mock.patch("synapse.api.requests")
 def test_get_nonce_success(mock_requests):
     """
-    arrange: set User parameters.
-    act: register the user.
-    assert: parameters are passed correctly.
+    arrange: none.
+    act: get nonce.
+    assert: _get_nonce return the correct value.
     """
     nonce_value = "nonce_value"
     mock_response = mock.MagicMock()
@@ -102,8 +102,8 @@ def test_get_nonce_success(mock_requests):
 
 def test_get_nonce_error(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: set User parameters.
-    act: register the user.
+    arrange: none.
+    act: get nonce.
     assert: NetworkError is raised.
     """
     mock_response_error = requests.exceptions.ConnectionError("Connection error")
@@ -111,3 +111,33 @@ def test_get_nonce_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("synapse.api.requests.get", mock_response)
     with pytest.raises(synapse.APIError, match="Failed to request"):
         synapse.api._get_nonce()
+
+
+@mock.patch("synapse.api.requests")
+def test_get_version_success(mock_requests):
+    """
+    arrange: none.
+    act: get version.
+    assert: get_version return the correct value.
+    """
+    extracted_version = "0.99.2rc1"
+    mock_response = mock.MagicMock()
+    mock_response.json.return_value = {
+        "server_version": f"{extracted_version} (b=develop, abcdef123)",
+        "python_version": "3.7.8",
+    }
+    mock_requests.get.return_value = mock_response
+    assert synapse.api.get_version() == extracted_version
+
+
+def test_get_version_error(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: none.
+    act: get version.
+    assert: NetworkError is raised.
+    """
+    mock_response_error = requests.exceptions.ConnectionError("Connection error")
+    mock_response = mock.Mock(side_effect=mock_response_error)
+    monkeypatch.setattr("synapse.api.requests.get", mock_response)
+    with pytest.raises(synapse.APIError, match="Failed to request"):
+        synapse.api.get_version()


### PR DESCRIPTION
WIP - Not ready for reviews but feel free to take a look.

This PR adds the Synapse version to the workload version so the user can check using the `juju status` command.
The version can be obtained through a request to the [API](https://matrix-org.github.io/synapse/latest/admin_api/version_api.html).

Out of the scope: the docs field was removed from metadata since now Charmcraft checks if the field is not empty. There is no documentation for Synapse yet.