### PR TITLE
Remove ops pg lib and pin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 jsonschema == 4.17.3
-ops >= 2.4.1
+ops == 2.5.1
 pydantic ==1.10.12
-ops-lib-pgsql >= 1.4
 psycopg2-binary ==2.9.7
-requests>=2,<3
+requests == 2.31.0


### PR DESCRIPTION
The ops-lib-pgsql is not needed anymore, as the legacy db relation has been removed