### PR TITLE
fix(libs): Add cosl library as unit test requirement

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
+    cosl
     coverage[toml]
     pytest
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This is needed as Observability have added a new library `cosl` for their code listed in libraries in PYDEPS, so we need to have this dependency in our tests as well. This is for unit tests and we might need it for integration as well.