### PR TITLE
Fix attributemap directory

### DIFF
--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -206,7 +206,7 @@ def _create_pysaml2_config(charm_state: CharmState) -> typing.Dict:
     # dont send uid in SAMLResponse so this will map
     # fullname to uid
     if "ubuntu.com" in saml_config["metadata_url"]:
-        sp_config["attribute_map_dir"] = "/data/attributemaps"
+        sp_config["attribute_map_dir"] = "/usr/local/attributemaps"
 
     return sp_config
 

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -128,7 +128,7 @@ listeners:
                     }
                 },
                 "allow_unknown_attributes": True,
-                "attribute_map_dir": "/data/attributemaps",
+                "attribute_map_dir": "/usr/local/attributemaps",
             },
             "user_mapping_provider": {
                 "config": {


### PR DESCRIPTION
### Overview

The rock adds attributesmap to /usr/loca.

### Rationale

This PRs fixes the configuration and unit test according to the ROCK.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD014 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)