### PR TITLE
Change attributemaps

### DIFF
--- a/synapse_rock/attributemaps/login_ubuntu.py
+++ b/synapse_rock/attributemaps/login_ubuntu.py
@@ -4,6 +4,8 @@
 MAP = {
     "identifier": "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
     "fro": {
-        'fullname': 'uid',
+        'username': 'uid',
+        'fullname': 'displayName',
+        'email': 'email',
     }
 }


### PR DESCRIPTION
### Overview

This change how Synapse maps the SAMLResponse from login.ubuntu to its user management.

### Rationale

Currently, the field being used (fullname) is not the best option.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
