### PR TITLE
Fix SAML entity_id usage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,5 +17,5 @@ options:
     type: string
     description: |
       The public-facing base URL that clients use to access this Homeserver.
-      Defaults to https://<server_name>/. Only used if there is integration with
-      SAML integrator charm.
+      It's used as entity_id if set instead of https://server_name. Only used if
+      there is integration with SAML integrator charm.

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -167,6 +167,20 @@ def enable_metrics(container: ops.Container) -> None:
         raise EnableMetricsError(str(exc)) from exc
 
 
+def get_entity_id(charm_state: CharmState) -> str:
+    """Get entity id.
+
+    Args:
+        charm_state: Instance of CharmState.
+
+    Returns:
+        entity id to be used on SAML configuration.
+    """
+    if charm_state.public_baseurl is not None:
+        return charm_state.public_baseurl
+    return f"https://{charm_state.server_name}"
+
+
 def _create_pysaml2_config(charm_state: CharmState) -> typing.Dict:
     """Create config as expected by pysaml2.
 
@@ -186,6 +200,7 @@ def _create_pysaml2_config(charm_state: CharmState) -> typing.Dict:
         )
 
     saml_config = charm_state.saml_config
+    entity_id = get_entity_id(charm_state=charm_state)
     sp_config = {
         "metadata": {
             "remote": [
@@ -197,12 +212,12 @@ def _create_pysaml2_config(charm_state: CharmState) -> typing.Dict:
         "allow_unknown_attributes": True,
         "service": {
             "sp": {
-                "entityId": saml_config["entity_id"],
+                "entityId": entity_id,
                 "allow_unsolicited": True,
             },
         },
     }
-    # login.staging.canonical.com and login.canonical.com
+    # login.staging.ubuntu.com and login.ubuntu.com
     # dont send uid in SAMLResponse so this will map
     # fullname to uid
     if "ubuntu.com" in saml_config["metadata_url"]:

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -167,20 +167,6 @@ def enable_metrics(container: ops.Container) -> None:
         raise EnableMetricsError(str(exc)) from exc
 
 
-def get_entity_id(charm_state: CharmState) -> str:
-    """Get entity id.
-
-    Args:
-        charm_state: Instance of CharmState.
-
-    Returns:
-        entity id to be used on SAML configuration.
-    """
-    if charm_state.public_baseurl is not None:
-        return charm_state.public_baseurl
-    return f"https://{charm_state.server_name}"
-
-
 def _create_pysaml2_config(charm_state: CharmState) -> typing.Dict:
     """Create config as expected by pysaml2.
 
@@ -200,7 +186,11 @@ def _create_pysaml2_config(charm_state: CharmState) -> typing.Dict:
         )
 
     saml_config = charm_state.saml_config
-    entity_id = get_entity_id(charm_state=charm_state)
+    entity_id = (
+        charm_state.public_baseurl
+        if charm_state.public_baseurl is not None
+        else f"https://{charm_state.server_name}"
+    )
     sp_config = {
         "metadata": {
             "remote": [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -219,7 +219,7 @@ async def grafana_app_fixture(
         app = await model.deploy(
             "grafana-k8s",
             application_name=grafana_app_name,
-            channel="1.0/edge",
+            channel="stable",
             trust=True,
         )
         await model.wait_for_idle(raise_on_blocked=True, status=ACTIVE_STATUS_NAME)
@@ -244,7 +244,7 @@ async def deploy_prometheus_fixture(
         app = await model.deploy(
             "prometheus-k8s",
             application_name=prometheus_app_name,
-            channel="1.0/edge",
+            channel="stable",
             trust=True,
         )
         await model.wait_for_idle(raise_on_blocked=True, status=ACTIVE_STATUS_NAME)

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -68,6 +68,22 @@ def test_enable_metrics_error(monkeypatch: pytest.MonkeyPatch):
         synapse.enable_metrics(container_mock)
 
 
+def test_enable_saml_config_file_not_found():
+    """
+    arrange: set synapse configuration.
+    act: enable SAML.
+    assert: EnableSAMLError is raised because config file is not found.
+    """
+    harness = Harness(SynapseCharm)
+    harness.update_config({"server_name": TEST_SERVER_NAME, "public_baseurl": TEST_SERVER_NAME})
+    harness.set_can_connect(SYNAPSE_CONTAINER_NAME, True)
+    harness.begin()
+
+    container = harness.model.unit.get_container(SYNAPSE_CONTAINER_NAME)
+    with pytest.raises(synapse.workload.EnableSAMLError, match="no such file"):
+        synapse.enable_saml(container, harness.charm._charm_state)
+
+
 def test_enable_saml_success():
     """
     arrange: set mock container with file.

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -68,22 +68,6 @@ def test_enable_metrics_error(monkeypatch: pytest.MonkeyPatch):
         synapse.enable_metrics(container_mock)
 
 
-def test_enable_saml_config_file_not_found():
-    """
-    arrange: set synapse configuration.
-    act: enable SAML.
-    assert: EnableSAMLError is raised because config file is not found.
-    """
-    harness = Harness(SynapseCharm)
-    harness.update_config({"server_name": TEST_SERVER_NAME, "public_baseurl": TEST_SERVER_NAME})
-    harness.set_can_connect(SYNAPSE_CONTAINER_NAME, True)
-    harness.begin()
-
-    container = harness.model.unit.get_container(SYNAPSE_CONTAINER_NAME)
-    with pytest.raises(synapse.workload.EnableSAMLError, match="no such file"):
-        synapse.enable_saml(container, harness.charm._charm_state)
-
-
 def test_enable_saml_success():
     """
     arrange: set mock container with file.

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -81,12 +81,13 @@ def test_enable_saml_success():
     harness.update_config({"server_name": TEST_SERVER_NAME, "public_baseurl": TEST_SERVER_NAME})
     relation_id = harness.add_relation("saml", "saml-integrator")
     harness.add_relation_unit(relation_id, "saml-integrator/0")
+    metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
     harness.update_relation_data(
         relation_id,
         "saml-integrator",
         {
             "entity_id": "https://login.staging.ubuntu.com",
-            "metadata_url": "https://login.staging.ubuntu.com/saml/metadata",
+            "metadata_url": metadata_url,
         },
     )
     harness.set_can_connect(SYNAPSE_CONTAINER_NAME, True)
@@ -118,12 +119,10 @@ listeners:
         "saml2_enabled": True,
         "saml2_config": {
             "sp_config": {
-                "metadata": {
-                    "remote": [{"url": "https://login.staging.ubuntu.com/saml/metadata"}]
-                },
+                "metadata": {"remote": [{"url": metadata_url}]},
                 "service": {
                     "sp": {
-                        "entityId": "https://login.staging.ubuntu.com",
+                        "entityId": TEST_SERVER_NAME,
                         "allow_unsolicited": True,
                     }
                 },


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

### Overview

The entity_id provided by SAML integrator charm is being wrongly used as SP entity_id instead of IDP entity_id. This PR fixes it by setting entity_id to public_baseurl if set or https://server_name.

### Rationale

This way the charm can integrate with the SAML integrator as expected.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
