### PR TITLE
Fix rock to dump the right file

### DIFF
--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -78,4 +78,4 @@ parts:
         plugin: dump
         source: attributemaps
         organize:
-            login_ubuntu.py: /usr/local/attributemaps/login_ubuntu.py
+            attributemaps/login_ubuntu.py: /usr/local/attributemaps/login_ubuntu.py

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -78,4 +78,4 @@ parts:
         plugin: dump
         source: attributemaps
         organize:
-            u1staging.py: /usr/local/attributemaps/u1staging.py
+            login_ubuntu.py: /usr/local/attributemaps/login_ubuntu.py

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -78,4 +78,4 @@ parts:
         plugin: dump
         source: attributemaps
         organize:
-            attributemaps/login_ubuntu.py: /usr/local/attributemaps/login_ubuntu.py
+            login_ubuntu.py: /usr/local/attributemaps/login_ubuntu.py


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

While setting Synapse environment, I noticed that one file was missing. At first I thought it would be some different version of the image but for my surprise, the rock was build successfully even trying to dump a non-existing file. This PR fixes it by adding the right name to dump.

### Rationale

Work as expected while mapping attributes.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
