### PR TITLE
WIP - Add well know file to nginx workload container

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,3 +25,11 @@ options:
     description: |
       Configures whether to enable Mjolnir - moderation tool for Matrix.
       Reference: https://github.com/matrix-org/mjolnir
+  delegation_server_name:
+    type: string
+    description: |
+      Delegation server name. If set, a .well-known/matrix/server file will be
+      created using this configuration as value to the key m.server. Example:
+      synapse.example.com:443
+      Reference: https://matrix-org.github.io/synapse/latest/delegate.html
+    default: ""

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -52,6 +52,12 @@ http {
       return 204;
     }
 
+    location /.well-known/matrix/ {
+      default_type application/json;
+      add_header Access-Control-Allow-Origin *;
+      root /var/www/html;
+    }
+
     location  / {
       proxy_read_timeout 300;
       proxy_pass http://localhost:8008;

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,6 +80,9 @@ class SynapseCharm(ops.CharmBase):
             self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
             return
         self.model.unit.status = ops.MaintenanceStatus("Configuring Synapse NGINX")
+        if self._charm_state.delegation_server_name:
+            logger.info("Setting NGINX .well-known/matrix/server file")
+            synapse.create_well_know_file(container, self._charm_state)
         self.pebble_service.replan_nginx(container)
         self.model.unit.status = ops.ActiveStatus()
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -27,6 +27,7 @@ KNOWN_CHARM_CONFIG = (
     "report_stats",
     "public_baseurl",
     "enable_mjolnir",
+    "delegation_server_name",
 )
 
 
@@ -54,12 +55,14 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
         report_stats: report_stats config.
         public_baseurl: public_baseurl config.
         enable_mjolnir: enable_mjolnir config.
+        delegation_server_name: delegation_server_name config.
     """
 
     server_name: str | None = Field(..., min_length=2)
     report_stats: str | None = Field(None)
     public_baseurl: str | None = Field(None)
     enable_mjolnir: bool = False
+    delegation_server_name: str | None = Field(None)
 
     class Config:  # pylint: disable=too-few-public-methods
         """Config class.
@@ -94,6 +97,7 @@ class CharmState:
         report_stats: report_stats config.
         public_baseurl: public_baseurl config.
         enable_mjolnir: enable_mjolnir config.
+        delegation_server_name: delegation_server_name config.
         datasource: datasource information.
         saml_config: saml configuration.
     """
@@ -151,6 +155,15 @@ class CharmState:
             bool: enable_mjolnir config.
         """
         return self._synapse_config.enable_mjolnir
+
+    @property
+    def delegation_server_name(self) -> typing.Optional[str]:
+        """Return sdelegation_erver_name config.
+
+        Returns:
+            str: delegation_server_name config.
+        """
+        return self._synapse_config.delegation_server_name
 
     @property
     def datasource(self) -> typing.Union[DatasourcePostgreSQL, None]:

--- a/src/constants.py
+++ b/src/constants.py
@@ -28,3 +28,4 @@ SYNAPSE_PORT = 8008
 SYNAPSE_SERVICE_NAME = "synapse"
 SYNAPSE_URL = "http://localhost:8008"
 TEST_SERVER_NAME = "server-name-configured.synapse.com"
+WELL_KNOW_FILE_PATH = "/var/www/html/.well-known/matrix/server"

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -23,6 +23,7 @@ from .workload import (  # noqa: F401
     check_nginx_ready,
     check_ready,
     create_mjolnir_config,
+    create_well_know_file,
     enable_metrics,
     enable_saml,
     execute_migrate_config,

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -214,7 +214,9 @@ def test_override_rate_limit_success(monkeypatch: pytest.MonkeyPatch):
     user = User(username=username, admin=True)
     admin_access_token = token_hex(16)
     server = token_hex(16)
-    synapse_config = SynapseConfig(server_name=server, report_stats="False", public_baseurl="")
+    synapse_config = SynapseConfig(
+        server_name=server, report_stats="False", public_baseurl="", delegation_server_name=""
+    )
     charm_state = CharmState(synapse_config=synapse_config, datasource=None, saml_config=None)
     expected_url = (
         f"http://localhost:8008/_synapse/admin/v1/users/@any-user:{server}/override_ratelimit"
@@ -242,7 +244,9 @@ def test_override_rate_limit_error(monkeypatch: pytest.MonkeyPatch):
     user = User(username=username, admin=True)
     admin_access_token = token_hex(16)
     server = token_hex(16)
-    synapse_config = SynapseConfig(server_name=server, report_stats="False", public_baseurl="")
+    synapse_config = SynapseConfig(
+        server_name=server, report_stats="False", public_baseurl="", delegation_server_name=""
+    )
     charm_state = CharmState(synapse_config=synapse_config, datasource=None, saml_config=None)
     expected_error_msg = "Failed to connect"
     do_request_mock = mock.MagicMock(side_effect=synapse.APIError(expected_error_msg))


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

In order to provide delegation, this PR adds a configuration where the user can set a delegation server name. This name will be used to create a server file provided by the NGINX workload container.
More details in [Delegation of incoming traffic](https://matrix-org.github.io/synapse/latest/delegate.html).

### Rationale

This way you can have a server_name like example.com but a URL to your Synapse as synapse.example.com.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
