### PR TITLE
Enable serve_server_wellknown

### DIFF
--- a/src/pebble.py
+++ b/src/pebble.py
@@ -96,6 +96,7 @@ class PebbleService:
         try:
             synapse.execute_migrate_config(container=container, charm_state=self._charm_state)
             synapse.enable_metrics(container=container)
+            synapse.enable_serve_server_wellknown(container=container)
             if self._charm_state.saml_config is not None:
                 logger.debug("pebble.change_config: Enabling SAML")
                 synapse.enable_saml(container=container, charm_state=self._charm_state)

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -25,6 +25,7 @@ from .workload import (  # noqa: F401
     create_mjolnir_config,
     enable_metrics,
     enable_saml,
+    enable_serve_server_wellknown,
     execute_migrate_config,
     get_environment,
     get_registration_shared_secret,

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -190,6 +190,24 @@ def enable_metrics(container: ops.Container) -> None:
         raise EnableMetricsError(str(exc)) from exc
 
 
+def enable_serve_server_wellknown(container: ops.Container) -> None:
+    """Change the Synapse configuration to enable server wellknown file.
+
+    Args:
+        container: Container of the charm.
+
+    Raises:
+        WorkloadError: something went wrong enabling configuration.
+    """
+    try:
+        config = container.pull(SYNAPSE_CONFIG_PATH).read()
+        current_yaml = yaml.safe_load(config)
+        current_yaml["serve_server_wellknown"] = True
+        container.push(SYNAPSE_CONFIG_PATH, yaml.safe_dump(current_yaml))
+    except ops.pebble.PathError as exc:
+        raise WorkloadError(str(exc)) from exc
+
+
 def _get_mjolnir_config(access_token: str, room_id: str) -> typing.Dict:
     """Create config as expected by mjolnir.
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Delegation is a Matrix feature that:
- Allows your Synapse server to be configured as example.com so, for example, users will be like user1:example.com
- But the URL can be different, for example, https://synapse.example.com

You need delegation for two scenarios:
1. The one mentioned above so you can route traffic to the expected URL
2. You want federation traffic to use a different port than 8448 (the default)

This PR addresses the situation 2 by enabling the configuration `serve_server_wellknown` making Synapse serve a ".well-known/matrix/server" file with the content:
```
{
    "m.server": "<server_name>:443"
}
```
Where <server_name> is the one configured in the Synapse instance.

### Rationale

Make federation traffic to use a different port than 8448. In this case, the port will be 443.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
