### PR TITLE
Add support for rockfile digest pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     },
     {
       "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,32 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^rockcraft.yaml$"],
+      "description": "Update base image references",
+      "matchStringsStrategy": "any",
+      "matchStrings": ["# renovate: build-base:\\s+(?<depName>[^:]*):(?<cur
+rentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
+      "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?
+<currentDigest>sha256:[0-9a-f]*))?"],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "enabled": true,
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true
+    },
+    {
+      "matchFiles": ["rockcraft.yaml"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     },
     {
       "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "enabled": false
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,8 @@
       "fileMatch": ["^rockcraft.yaml$"],
       "description": "Update base image references",
       "matchStringsStrategy": "any",
-      "matchStrings": ["# renovate: build-base:\\s+(?<depName>[^:]*):(?<cur
-rentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
-      "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?
-<currentDigest>sha256:[0-9a-f]*))?"],
+      "matchStrings": ["# renovate: build-base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
+      "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?"],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
@@ -26,7 +24,7 @@ rentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
     },
     {
       "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview
is-devops-botFeature/template filesFeature/template files
<!-- A high level overview of the change -->

### Rationale

Changes renovate.json to include support for pinning docker digests in rock files.

<!-- The reason the change is needed -->

### Juju Events Changes

n/a

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

n/a

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

n/a

<!-- Any changes to charm libraries -->

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
