### PR TITLE
Add proxy environment variables

### DIFF
--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -101,7 +101,7 @@ Return: The CharmState instance created by the provided charm.
 ---
 
 ## <kbd>class</kbd> `ProxyConfig`
-Configuration for accessing Jenkins through proxy. 
+Configuration for accessing Synapse through proxy. 
 
 
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -17,7 +17,7 @@ Exception raised when a charm configuration is found to be invalid.
 
 Attrs:  msg (str): Explanation of the error. 
 
-<a href="../src/charm_state.py#L45"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -49,13 +49,25 @@ State of the Charm.
  - <b>`synapse_config`</b>:  synapse configuration. 
  - <b>`datasource`</b>:  datasource information. 
  - <b>`saml_config`</b>:  saml configuration. 
+ - <b>`proxy`</b>:  proxy information. 
 
+
+---
+
+#### <kbd>property</kbd> proxy
+
+Get charm proxy information from juju charm environment. 
+
+
+
+**Returns:**
+  charm proxy information in the form of ProxyConfig. 
 
 
 
 ---
 
-<a href="../src/charm_state.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L173"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -88,6 +100,23 @@ Return: The CharmState instance created by the provided charm.
 
 ---
 
+## <kbd>class</kbd> `ProxyConfig`
+Configuration for accessing Jenkins through proxy. 
+
+
+
+**Attributes:**
+ 
+ - <b>`http_proxy`</b>:  The http proxy URL. 
+ - <b>`https_proxy`</b>:  The https proxy URL. 
+ - <b>`no_proxy`</b>:  Comma separated list of hostnames to bypass proxy. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `SynapseConfig`
 Represent Synapse builtin configuration values. 
 
@@ -98,7 +127,7 @@ Attrs:  server_name: server_name config.  report_stats: report_stats config.  pu
 
 ---
 
-<a href="../src/charm_state.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `set_default_smtp_notif_from`
 
@@ -125,7 +154,7 @@ Set server_name as default value to smtp_notif_from.
 
 ---
 
-<a href="../src/charm_state.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_yes_or_no`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -55,7 +55,7 @@ class CharmConfigInvalidError(Exception):
 
 
 class ProxyConfig(BaseModel):  # pylint: disable=too-few-public-methods
-    """Configuration for accessing Jenkins through proxy.
+    """Configuration for accessing Synapse through proxy.
 
     Attributes:
         http_proxy: The http proxy URL.

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -6,16 +6,19 @@
 """State of the Charm."""
 import dataclasses
 import itertools
+import os
 import typing
 
 import ops
 
 # pydantic is causing this no-name-in-module problem
 from pydantic import (  # pylint: disable=no-name-in-module,import-error
+    AnyHttpUrl,
     BaseModel,
     Extra,
     Field,
     ValidationError,
+    parse_obj_as,
     validator,
 )
 
@@ -49,6 +52,20 @@ class CharmConfigInvalidError(Exception):
             msg (str): Explanation of the error.
         """
         self.msg = msg
+
+
+class ProxyConfig(BaseModel):  # pylint: disable=too-few-public-methods
+    """Configuration for accessing Jenkins through proxy.
+
+    Attributes:
+        http_proxy: The http proxy URL.
+        https_proxy: The https proxy URL.
+        no_proxy: Comma separated list of hostnames to bypass proxy.
+    """
+
+    http_proxy: typing.Optional[AnyHttpUrl]
+    https_proxy: typing.Optional[AnyHttpUrl]
+    no_proxy: typing.Optional[str]
 
 
 class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
@@ -130,11 +147,28 @@ class CharmState:
         synapse_config: synapse configuration.
         datasource: datasource information.
         saml_config: saml configuration.
+        proxy: proxy information.
     """
 
     synapse_config: SynapseConfig
     datasource: typing.Optional[DatasourcePostgreSQL]
     saml_config: typing.Optional[SAMLConfiguration]
+
+    @property
+    def proxy(self) -> "ProxyConfig":
+        """Get charm proxy information from juju charm environment.
+
+        Returns:
+            charm proxy information in the form of ProxyConfig.
+        """
+        http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+        https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+        no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+        return ProxyConfig(
+            http_proxy=parse_obj_as(AnyHttpUrl, http_proxy) if http_proxy else None,
+            https_proxy=parse_obj_as(AnyHttpUrl, https_proxy) if https_proxy else None,
+            no_proxy=no_proxy,
+        )
 
     @classmethod
     def from_charm(

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -517,4 +517,9 @@ def get_environment(charm_state: CharmState) -> typing.Dict[str, str]:
         environment["POSTGRES_PORT"] = datasource["port"]
         environment["POSTGRES_USER"] = datasource["user"]
         environment["POSTGRES_PASSWORD"] = datasource["password"]
+    for proxy_variable in ("http_proxy", "https_proxy", "no_proxy"):
+        proxy_value = getattr(charm_state.proxy, proxy_variable)
+        if proxy_value:
+            environment[proxy_variable] = str(proxy_value)
+            environment[proxy_variable.upper()] = str(proxy_value)
     return environment


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Configure proxy-related environmental variables automatically according to the Juju model settings.

### Rationale

This is needed to make Federation (as well any request done by the Synapse) work.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
