### PR TITLE
Workaround - New issue templates for chat.ubuntu.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
-name: Bug Report
-description: File a bug report
-labels: ["Type: Bug", "Status: Triage"]
+name: Operator Bug Report
+description: File a bug report on the synapse operator
+labels: ["Type: Bug", "Status: Triage", "Context: Operator"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,6 +1,6 @@
-name: Enhancement Proposal
-description: File an enhancement proposal
-labels: ["Type: Enhancement", "Status: Triage"]
+name: Operator Enhancement Proposal
+description: File an enhancement proposal for the synapse operator
+labels: ["Type: Enhancement", "Status: Triage", "Context: Operator"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/matrix_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/matrix_bug_report.yml
@@ -1,0 +1,45 @@
+name: Matrix Deployment Bug Report
+description: Report a bug with the chat.ubuntu.com deployment
+labels: ["Type: Bug", "Status: Triage", "Context: deployment"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to report an issue with the ubuntu.com Matrix instance. We'd
+        like to learn more about your issue and appreciate your support. Please take a moment to
+        check the existing issues in case someone else has encountered a similar issues.
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please attach screenshots, videos or logs if you can.
+      placeholder: Tell us what you see!
+      value: |
+        1. Where are you starting? What can you see?
+        2. What do you click?
+        3. More steps…
+    validations:
+      required: true
+  - type: textarea
+    id: result
+    attributes:
+      label: Outcome
+      placeholder: Tell us what went wrong
+      value: |
+        #### What did you expect?
+
+        #### What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: client-info
+    attributes:
+      label: Client information
+      description: >
+        Provide information about the Matrix client you are using
+      value: |
+        **Name**:
+        **Version**:
+        **OS and install type**:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/matrix_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/matrix_enhancement.yml
@@ -1,0 +1,37 @@
+name: Matrix Deployment Enhancement
+description: Suggest a feature for the chat.ubuntu.com deployment
+labels: ["Type: Enhancement", "Status: Triage", "deployment"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        We're looking forward to hearing how you think chat.ubuntu.com could be improved. Be sure to
+        give us all the context we need to understand your request. Thank you for your support!
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Your use case
+      description: What would you like to be able to do? Please feel welcome to include screenshots or mock ups.
+      placeholder: Tell us what you would like to do!
+      value: |
+        #### What would you like to do?
+
+        #### Why would you like to do it?
+
+        #### How would you like to achieve it?
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Have you considered any alternatives?
+      placeholder: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      placeholder: Is there anything else you'd like to add?
+    validations:
+      required: false


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This is a copy from https://github.com/canonical/synapse-operator/pull/69 while we work on a solution to allow external contributors push packages.

### Rationale

Add new issue templates.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
