### PR TITLE
Add Synapse NGINX pebble ready event handler

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -75,7 +75,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L95"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 
@@ -87,7 +87,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L211"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_admin_access_token`
 
@@ -101,17 +101,5 @@ Get admin access token.
 
 **Returns:**
   admin access token or None if fails. 
-
----
-
-<a href="../src/charm.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `replan_nginx`
-
-```python
-replan_nginx() → None
-```
-
-Replan NGINX. 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,7 +96,7 @@ class SynapseCharm(ops.CharmBase):
         """Change configuration."""
         container = self.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         if not container.can_connect():
-            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
             return
         self.model.unit.status = ops.MaintenanceStatus("Configuring Synapse")
         try:
@@ -106,7 +106,7 @@ class SynapseCharm(ops.CharmBase):
             return
         container = self.unit.get_container(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
         if not container.can_connect():
-            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self.unit.status = ops.MaintenanceStatus("Waiting for Synapse NGINX pebble")
             return
         self.pebble_service.replan_nginx(container)
         self.model.unit.status = ops.ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class SynapseCharm(ops.CharmBase):
         """Set workload version with Synapse version."""
         container = self.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         if not container.can_connect():
-            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
             return
         try:
             synapse_version = synapse.get_version()
@@ -136,7 +136,7 @@ class SynapseCharm(ops.CharmBase):
         """Handle synapse nginx pebble ready event."""
         container = self.unit.get_container(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
         if not container.can_connect():
-            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self.unit.status = ops.MaintenanceStatus("Waiting for Synapse NGINX pebble")
             return
         self.pebble_service.replan_nginx(container)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,22 +82,15 @@ class SynapseCharm(ops.CharmBase):
             self._mjolnir = Mjolnir(self, charm_state=self._charm_state)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.reset_instance_action, self._on_reset_instance_action)
-        self.framework.observe(self.on.synapse_pebble_ready, self._on_pebble_ready)
+        self.framework.observe(self.on.synapse_pebble_ready, self._on_synapse_pebble_ready)
+        self.framework.observe(
+            self.on.synapse_nginx_pebble_ready, self._on_synapse_nginx_pebble_ready
+        )
         self.framework.observe(self.on.register_user_action, self._on_register_user_action)
         self.framework.observe(
             self.on.promote_user_admin_action, self._on_promote_user_admin_action
         )
         self.framework.observe(self.on.anonymize_user_action, self._on_anonymize_user_action)
-
-    def replan_nginx(self) -> None:
-        """Replan NGINX."""
-        container = self.unit.get_container(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
-        if not container.can_connect():
-            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
-            return
-        self.model.unit.status = ops.MaintenanceStatus("Configuring Synapse NGINX")
-        self.pebble_service.replan_nginx(container)
-        self.model.unit.status = ops.ActiveStatus()
 
     def change_config(self) -> None:
         """Change configuration."""
@@ -111,7 +104,12 @@ class SynapseCharm(ops.CharmBase):
         except PebbleServiceError as exc:
             self.model.unit.status = ops.BlockedStatus(str(exc))
             return
-        self.replan_nginx()
+        container = self.unit.get_container(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
+        if not container.can_connect():
+            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            return
+        self.pebble_service.replan_nginx(container)
+        self.model.unit.status = ops.ActiveStatus()
 
     def _set_workload_version(self) -> None:
         """Set workload version with Synapse version."""
@@ -130,9 +128,17 @@ class SynapseCharm(ops.CharmBase):
         self.change_config()
         self._set_workload_version()
 
-    def _on_pebble_ready(self, _: ops.HookEvent) -> None:
-        """Handle pebble ready event."""
+    def _on_synapse_pebble_ready(self, _: ops.HookEvent) -> None:
+        """Handle synapse pebble ready event."""
         self.change_config()
+
+    def _on_synapse_nginx_pebble_ready(self, _: ops.HookEvent) -> None:
+        """Handle synapse nginx pebble ready event."""
+        container = self.unit.get_container(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
+        if not container.can_connect():
+            self.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            return
+        self.pebble_service.replan_nginx(container)
 
     def _on_reset_instance_action(self, event: ActionEvent) -> None:
         """Reset instance and report action result.

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -62,7 +62,7 @@ class DatabaseObserver(Object):
         """Change the configuration."""
         container = self._charm.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         if not container.can_connect() or self._pebble_service is None:
-            self._charm.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self._charm.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
             return
         try:
             self._pebble_service.change_config(container)

--- a/src/mjolnir.py
+++ b/src/mjolnir.py
@@ -73,7 +73,7 @@ class Mjolnir(ops.Object):  # pylint: disable=too-few-public-methods
             return
         container = self._charm.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         if not container.can_connect():
-            self._charm.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self._charm.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
             return
         mjolnir_service = container.get_services(MJOLNIR_SERVICE_NAME)
         if mjolnir_service:
@@ -151,7 +151,7 @@ class Mjolnir(ops.Object):  # pylint: disable=too-few-public-methods
         """
         container = self._charm.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         if not container.can_connect():
-            self._charm.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self._charm.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
             return
         self._charm.model.unit.status = ops.MaintenanceStatus("Configuring Mjolnir")
         mjolnir_user = actions.register_user(

--- a/src/saml_observer.py
+++ b/src/saml_observer.py
@@ -54,7 +54,7 @@ class SAMLObserver(Object):
         """Enable  SAML."""
         container = self._charm.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         if not container.can_connect() or self._pebble_service is None:
-            self._charm.unit.status = ops.MaintenanceStatus("Waiting for pebble")
+            self._charm.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
             return
         try:
             self._pebble_service.enable_saml(container)

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -121,7 +121,7 @@ def check_nginx_ready() -> ops.pebble.CheckDict:
     check = Check(CHECK_NGINX_READY_NAME)
     check.override = "replace"
     check.level = "ready"
-    check.tcp = {"port": SYNAPSE_NGINX_PORT}
+    check.http = {"url": f"http://localhost:{SYNAPSE_NGINX_PORT}/health"}
     return check.to_dict()
 
 

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -339,9 +339,10 @@ def enable_federation_domain_whitelist(container: ops.Container, charm_state: Ch
         config = container.pull(SYNAPSE_CONFIG_PATH).read()
         current_yaml = yaml.safe_load(config)
         if charm_state.synapse_config.federation_domain_whitelist is not None:
-            current_yaml[
-                "federation_domain_whitelist"
-            ] = charm_state.synapse_config.federation_domain_whitelist.split(",")
+            current_yaml["federation_domain_whitelist"] = [
+                item.strip()
+                for item in charm_state.synapse_config.federation_domain_whitelist.split(",")
+            ]
             container.push(SYNAPSE_CONFIG_PATH, yaml.safe_dump(current_yaml))
     except ops.pebble.PathError as exc:
         raise WorkloadError(str(exc)) from exc

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -270,9 +270,11 @@ async def grafana_app_fixture(
     """Deploy grafana."""
     async with ops_test.fast_forward():
         app = await model.deploy(
-            "grafana-k8s",
+            grafana_app_name,
             application_name=grafana_app_name,
             channel="stable",
+            series="focal",
+            revision=82,  # last one compatible with Juju 2
             trust=True,
         )
         await model.wait_for_idle(raise_on_blocked=True, status=ACTIVE_STATUS_NAME)
@@ -295,9 +297,11 @@ async def deploy_prometheus_fixture(
     """Deploy prometheus."""
     async with ops_test.fast_forward():
         app = await model.deploy(
-            "ch:prometheus-k8s-129",
+            prometheus_app_name,
             application_name=prometheus_app_name,
             channel="stable",
+            series="focal",
+            revision=129,  # last one compatible with Juju 2
             trust=True,
         )
         await model.wait_for_idle(raise_on_blocked=True, status=ACTIVE_STATUS_NAME)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -295,7 +295,7 @@ async def deploy_prometheus_fixture(
     """Deploy prometheus."""
     async with ops_test.fast_forward():
         app = await model.deploy(
-            "prometheus-k8s",
+            "ch:prometheus-k8s-129",
             application_name=prometheus_app_name,
             channel="stable",
             trust=True,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -418,3 +418,18 @@ def test_disable_password_config_is_called(
     harness.charm.pebble_service.change_config(container=MagicMock())
 
     disable_password_config_mock.assert_called_once()
+
+
+def test_nginx_replan(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    arrange: start the Synapse charm, mock replan_nginx call.
+    act: fire that NGINX container is ready.
+    assert: Pebble Service replan NGINX is called.
+    """
+    harness.begin()
+    replan_nginx_mock = MagicMock()
+    monkeypatch.setattr(harness.charm.pebble_service, "replan_nginx", replan_nginx_mock)
+
+    harness.container_pebble_ready(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
+
+    replan_nginx_mock.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.42.4
+    juju==2.9.45.0
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

If for any reason the Synapse NGINX pebble check fails, the container is restarted, a pebble ready event emitted but since there is no handler for it, the pebble plan is not re-created. This PR solves this by adding a handler to this event.

Not related but since is a small change this PR also add a strip to each item of federation domain whitelist as suggested [here](https://github.com/canonical/synapse-operator/pull/94).

### Rationale

Guarantee that Synapse NGINX pebble layer is always planned.

### Juju Events Changes

Add _on_synapse_nginx_pebble_ready

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
