### PR TITLE
Upgrade Synapse (already published)

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -75,7 +75,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 
@@ -87,7 +87,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L211"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_admin_access_token`
 
@@ -104,7 +104,7 @@ Get admin access token.
 
 ---
 
-<a href="../src/charm.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `replan_nginx`
 

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -5,9 +5,9 @@ name: synapse
 summary: Synapse rock
 description: Synapse OCI image for the Synapse charm
 version: "1.0"
-base: ubuntu:22.04
+base: ubuntu@22.04
 # renovate: base: ubuntu:22.04@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 # renovate: build-base: ubuntu:22.04@sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
 license: Apache-2.0
 platforms:
@@ -52,7 +52,7 @@ parts:
         plugin: nil
         source: https://github.com/matrix-org/synapse/
         source-type: git
-        source-tag: v1.85.2
+        source-tag: v1.96.1
         override-build: |
             craftctl default
             export RUSTUP_HOME=/rust
@@ -61,6 +61,7 @@ parts:
             export CARGO_NET_GIT_FETCH_WITH_CLI=false
             mkdir -p /rust /cargo /synapse /install
             curl -m 30 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain stable --profile minimal
+            /rust/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc -V > $CRAFT_PART_INSTALL/rust-version
             pip3 install -U pip setuptools
             pip3 install --root-user-action=ignore "poetry==1.3.2"
             cp pyproject.toml poetry.lock /synapse/


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR changes the ROCK image to install Synapse version 1.96.1. Also, since SBOM is not available for ROCKs yet, it creates a file rust-version to make it possible check the Rust version installed at the time of the image creation.

### Rationale

Upgrade Synapse.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
