### PR TITLE
Add allow_public_rooms_over_federation configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,12 @@
 # See LICENSE file for licensing details.
 
 options:
+  allow_public_rooms_over_federation:
+    type: boolean
+    default: false
+    description: |
+      Allows any other homeserver to fetch the server's public rooms directory
+      via federation.
   enable_mjolnir:
     type: boolean
     default: false

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -67,7 +67,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -124,12 +124,13 @@ Represent Synapse builtin configuration values.
 
 **Attributes:**
  
- - <b>`server_name`</b>:  server_name config. 
- - <b>`report_stats`</b>:  report_stats config. 
- - <b>`public_baseurl`</b>:  public_baseurl config. 
+ - <b>`allow_public_rooms_over_federation`</b>:  allow_public_rooms_over_federation config. 
  - <b>`enable_mjolnir`</b>:  enable_mjolnir config. 
  - <b>`enable_password_config`</b>:  enable_password_config config. 
  - <b>`federation_domain_whitelist`</b>:  federation_domain_whitelist config. 
+ - <b>`public_baseurl`</b>:  public_baseurl config. 
+ - <b>`report_stats`</b>:  report_stats config. 
+ - <b>`server_name`</b>:  server_name config. 
  - <b>`smtp_enable_tls`</b>:  enable tls while connecting to SMTP server. 
  - <b>`smtp_host`</b>:  SMTP host. 
  - <b>`smtp_notif_from`</b>:  defines the "From" address to use when sending emails. 
@@ -142,7 +143,7 @@ Represent Synapse builtin configuration values.
 
 ---
 
-<a href="../src/charm_state.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `set_default_smtp_notif_from`
 
@@ -169,7 +170,7 @@ Set server_name as default value to smtp_notif_from.
 
 ---
 
-<a href="../src/charm_state.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L134"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_yes_or_no`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -57,7 +57,7 @@ Change the configuration.
 
 ---
 
-<a href="../src/pebble.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `enable_saml`
 
@@ -117,7 +117,7 @@ Replan Synapse NGINX service.
 
 ---
 
-<a href="../src/pebble.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reset_instance`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -74,12 +74,13 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
     """Represent Synapse builtin configuration values.
 
     Attributes:
-        server_name: server_name config.
-        report_stats: report_stats config.
-        public_baseurl: public_baseurl config.
+        allow_public_rooms_over_federation: allow_public_rooms_over_federation config.
         enable_mjolnir: enable_mjolnir config.
         enable_password_config: enable_password_config config.
         federation_domain_whitelist: federation_domain_whitelist config.
+        public_baseurl: public_baseurl config.
+        report_stats: report_stats config.
+        server_name: server_name config.
         smtp_enable_tls: enable tls while connecting to SMTP server.
         smtp_host: SMTP host.
         smtp_notif_from: defines the "From" address to use when sending emails.
@@ -88,12 +89,13 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
         smtp_user: username to authenticate to SMTP host.
     """
 
-    server_name: str = Field(..., min_length=2)
-    report_stats: str | None = Field(None)
-    public_baseurl: str | None = Field(None)
+    allow_public_rooms_over_federation: bool = False
     enable_mjolnir: bool = False
     enable_password_config: bool = True
     federation_domain_whitelist: str | None = Field(None)
+    public_baseurl: str | None = Field(None)
+    report_stats: str | None = Field(None)
+    server_name: str = Field(..., min_length=2)
     smtp_enable_tls: bool = True
     smtp_host: str | None = Field(None)
     smtp_notif_from: str | None = Field(None)

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -97,6 +97,8 @@ class PebbleService:
                 synapse.enable_federation_domain_whitelist(
                     container=container, charm_state=self._charm_state
                 )
+            if self._charm_state.synapse_config.allow_public_rooms_over_federation:
+                synapse.enable_allow_public_rooms_over_federation(container=container)
             self.restart_synapse(container)
         except (synapse.WorkloadError, ops.pebble.PathError) as exc:
             raise PebbleServiceError(str(exc)) from exc

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -54,6 +54,7 @@ from .workload import (  # noqa: F401
     check_ready,
     create_mjolnir_config,
     disable_password_config,
+    enable_allow_public_rooms_over_federation,
     enable_federation_domain_whitelist,
     enable_metrics,
     enable_saml,

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -348,6 +348,24 @@ def enable_federation_domain_whitelist(container: ops.Container, charm_state: Ch
         raise WorkloadError(str(exc)) from exc
 
 
+def enable_allow_public_rooms_over_federation(container: ops.Container) -> None:
+    """Change the Synapse configuration to allow public rooms in federation.
+
+    Args:
+        container: Container of the charm.
+
+    Raises:
+        WorkloadError: something went wrong enabling configuration.
+    """
+    try:
+        config = container.pull(SYNAPSE_CONFIG_PATH).read()
+        current_yaml = yaml.safe_load(config)
+        current_yaml["allow_public_rooms_over_federation"] = True
+        container.push(SYNAPSE_CONFIG_PATH, yaml.safe_dump(current_yaml))
+    except ops.pebble.PathError as exc:
+        raise WorkloadError(str(exc)) from exc
+
+
 def _get_mjolnir_config(access_token: str, room_id: str) -> typing.Dict:
     """Create config as expected by mjolnir.
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -433,3 +433,22 @@ def test_nginx_replan(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None
     harness.container_pebble_ready(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
 
     replan_nginx_mock.assert_called_once()
+
+
+def test_nginx_replan_failure(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    arrange: start the Synapse charm, mock replan_nginx call and set the container as down.
+    act: fire that NGINX container is ready.
+    assert: Pebble Service replan NGINX is not called.
+    """
+    harness.begin()
+    replan_nginx_mock = MagicMock()
+    monkeypatch.setattr(harness.charm.pebble_service, "replan_nginx", replan_nginx_mock)
+
+    harness.set_can_connect(
+        harness.model.unit.containers[synapse.SYNAPSE_NGINX_CONTAINER_NAME], False
+    )
+    harness.container_pebble_ready(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
+
+    replan_nginx_mock.assert_called_once()
+    assert isinstance(harness.model.unit.status, ops.MaintenanceStatus)

--- a/tests/unit/test_mjolnir.py
+++ b/tests/unit/test_mjolnir.py
@@ -188,6 +188,30 @@ def test_on_collect_status_api_error(harness: Harness, monkeypatch: pytest.Monke
     enable_mjolnir_mock.assert_not_called()
 
 
+def test_on_collect_status_admin_none(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    arrange: start the Synapse charm, set server_name, mock container, mock _admin_access_token
+        to be None.
+    act: call _on_collect_status.
+    assert: mjolnir is not enabled and the model status is Maintenance.
+    """
+    harness.update_config({"enable_mjolnir": True})
+    harness.begin_with_initial_hooks()
+    harness.set_leader(True)
+    monkeypatch.setattr(Mjolnir, "_admin_access_token", None)
+    enable_mjolnir_mock = MagicMock(return_value=None)
+    monkeypatch.setattr(Mjolnir, "enable_mjolnir", enable_mjolnir_mock)
+    charm_state_mock = MagicMock()
+    charm_state_mock.enable_mjolnir = True
+    harness.charm._mjolnir._charm_state = charm_state_mock
+
+    event_mock = MagicMock()
+    harness.charm._mjolnir._on_collect_status(event_mock)
+
+    enable_mjolnir_mock.assert_not_called()
+    assert isinstance(harness.model.unit.status, ops.MaintenanceStatus)
+
+
 def test_enable_mjolnir(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None:
     """
     arrange: start the Synapse charm, set server_name, mock calls to validate args.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

While working with federation, one might want toallow public rooms over federation. This configuration allows that.

Reference: https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#allow_public_rooms_over_federation

### Rationale

Change allow_public_rooms_over_federation configuration.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
