### PR TITLE
Use self-hosted runner for integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,3 +12,5 @@ jobs:
       chaos-enabled: false
       chaos-experiments: pod-delete
       trivy-image-config: "trivy.yaml"
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"

--- a/tox.ini
+++ b/tox.ini
@@ -119,6 +119,8 @@ deps =
     pytest
     pytest-asyncio
     pytest-operator
+    # Type error problem with newer version of macaroonbakery
+    macaroonbakery==1.3.2
     git+https://github.com/canonical/saml-test-idp.git
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Use `edge` self-hosted runner for integration test

### Rationale

- Reduce load on GitHub-provided runner on the organisation.
- Test out the edge revision of github-runner charm on this repo.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
