### PR TITLE
Update nginx proxy_pass from localhost to 127.0.0.1

### DIFF
--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -54,7 +54,7 @@ http {
 
     location  / {
       proxy_read_timeout 300;
-      proxy_pass http://localhost:8008;
+      proxy_pass http://127.0.0.1:8008;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header Host $http_host;


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Nginx container is logging lines like the following one:
`2023-11-27T13:51:05.555Z [synapse-nginx] 2023/11/27 13:51:05 [error] 34#34: *736 no live upstreams while connecting to upstream`...


<!-- A high level overview of the change -->

### Rationale

The error log can be removed changing `proxy_pass` directive from `localhost` to `127.0.0.1` (see [here](https://stackoverflow.com/questions/49767001/how-to-solve-nginx-no-live-upstreams-while-connecting-to-upstream-client) for more information)

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
