### PR TITLE
Fix so nginx_pebble_ready can report active status if all is correct

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -87,7 +87,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L252"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_admin_access_token`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,11 +104,44 @@ class SynapseCharm(ops.CharmBase):
         except PebbleServiceError as exc:
             self.model.unit.status = ops.BlockedStatus(str(exc))
             return
+        self._set_unit_status()
+
+    # This method contains a similar check that the one done for the
+    # Synapse container and service in mjolnir.py
+    # Until a refactoring is done for a different way of checking and setting
+    # the unit status in a hollistic way, both checks will be done.
+    # pylint: disable=R0801
+    def _set_unit_status(self) -> None:
+        """Set unit status depending on Synapse and NGINX state."""
+        # If the unit is in a blocked state, do not change it, as it
+        # was set by a problem or error with the configuration
+        if isinstance(self.unit.status, ops.BlockedStatus):
+            return
+        # Synapse checks
+        container = self.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
+        if not container.can_connect():
+            self.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
+            return
+        synapse_service = container.get_services(synapse.SYNAPSE_SERVICE_NAME)
+        synapse_not_active = [
+            service for service in synapse_service.values() if not service.is_running()
+        ]
+        if not synapse_service or synapse_not_active:
+            self.unit.status = ops.MaintenanceStatus("Waiting for Synapse")
+            return
+        # NGINX checks
         container = self.unit.get_container(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
         if not container.can_connect():
             self.unit.status = ops.MaintenanceStatus("Waiting for Synapse NGINX pebble")
             return
-        self.pebble_service.replan_nginx(container)
+        nginx_service = container.get_services(synapse.SYNAPSE_NGINX_SERVICE_NAME)
+        nginx_not_active = [
+            service for service in nginx_service.values() if not service.is_running()
+        ]
+        if not nginx_service or nginx_not_active:
+            self.unit.status = ops.MaintenanceStatus("Waiting for NGINX")
+            return
+        # All checks passed, the unit is active
         self.model.unit.status = ops.ActiveStatus()
 
     def _set_workload_version(self) -> None:
@@ -139,6 +172,7 @@ class SynapseCharm(ops.CharmBase):
             self.unit.status = ops.MaintenanceStatus("Waiting for Synapse NGINX pebble")
             return
         self.pebble_service.replan_nginx(container)
+        self._set_unit_status()
 
     def _on_reset_instance_action(self, event: ActionEvent) -> None:
         """Reset instance and report action result.

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -198,7 +198,7 @@ class PebbleService:
             "summary": "Synapse nginx layer",
             "description": "Synapse nginx layer",
             "services": {
-                "synapse-nginx": {
+                synapse.SYNAPSE_NGINX_SERVICE_NAME: {
                     "override": "replace",
                     "summary": "Nginx service",
                     "command": "/usr/sbin/nginx",

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -45,6 +45,7 @@ from .workload import (  # noqa: F401
     SYNAPSE_CONTAINER_NAME,
     SYNAPSE_NGINX_CONTAINER_NAME,
     SYNAPSE_NGINX_PORT,
+    SYNAPSE_NGINX_SERVICE_NAME,
     SYNAPSE_SERVICE_NAME,
     ExecResult,
     WorkloadError,

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -31,6 +31,7 @@ SYNAPSE_CONFIG_PATH = f"{SYNAPSE_CONFIG_DIR}/homeserver.yaml"
 SYNAPSE_CONTAINER_NAME = "synapse"
 SYNAPSE_NGINX_CONTAINER_NAME = "synapse-nginx"
 SYNAPSE_NGINX_PORT = 8080
+SYNAPSE_NGINX_SERVICE_NAME = "synapse-nginx"
 SYNAPSE_SERVICE_NAME = "synapse"
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -453,6 +453,7 @@ def test_nginx_replan(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None
     replan_nginx_mock = MagicMock()
     monkeypatch.setattr(harness.charm.pebble_service, "replan_nginx", replan_nginx_mock)
 
+    harness.container_pebble_ready(synapse.SYNAPSE_CONTAINER_NAME)
     harness.container_pebble_ready(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
 
     replan_nginx_mock.assert_called_once()
@@ -460,7 +461,7 @@ def test_nginx_replan(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_nginx_replan_failure(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    arrange: start the Synapse charm, mock replan_nginx call and set the container as down.
+    arrange: start the Synapse charm, mock replan_nginx call and set the NGINX container as down.
     act: fire that NGINX container is ready.
     assert: Pebble Service replan NGINX is not called.
     """
@@ -468,10 +469,51 @@ def test_nginx_replan_failure(harness: Harness, monkeypatch: pytest.MonkeyPatch)
     replan_nginx_mock = MagicMock()
     monkeypatch.setattr(harness.charm.pebble_service, "replan_nginx", replan_nginx_mock)
 
-    harness.set_can_connect(
-        harness.model.unit.containers[synapse.SYNAPSE_NGINX_CONTAINER_NAME], False
-    )
+    container = harness.model.unit.containers[synapse.SYNAPSE_NGINX_CONTAINER_NAME]
+    harness.set_can_connect(container, False)
+    # harness.container_pebble_ready cannot be used as it sets the set_can_connect to True
+    harness.charm.on[synapse.SYNAPSE_NGINX_CONTAINER_NAME].pebble_ready.emit(container)
+
+    replan_nginx_mock.assert_not_called()
+    assert isinstance(harness.model.unit.status, ops.MaintenanceStatus)
+
+
+def test_nginx_replan_with_synapse_container_down(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    arrange: start Synapse charm with Synapse container as down, and mock replan_nginx
+    act: Fire that NGINX container is ready
+    assert: Pebble Service replan NGINX is called but unit is in maintenance
+        waiting for Synapse pebble.
+    """
+    harness.begin()
+    replan_nginx_mock = MagicMock()
+    monkeypatch.setattr(harness.charm.pebble_service, "replan_nginx", replan_nginx_mock)
+
+    container = harness.model.unit.containers[synapse.SYNAPSE_CONTAINER_NAME]
+    harness.set_can_connect(container, False)
+
     harness.container_pebble_ready(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
 
     replan_nginx_mock.assert_called_once()
-    assert isinstance(harness.model.unit.status, ops.MaintenanceStatus)
+    assert harness.model.unit.status == ops.MaintenanceStatus("Waiting for Synapse pebble")
+
+
+def test_nginx_replan_with_synapse_service_not_existing(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    arrange: start Synapse charm with Synapse container but without synapse service,
+        and mock replan_nginx
+    act: Fire that NGINX container is ready
+    assert: Pebble Service replan NGINX is called but unit is in maintenance waiting for Synapse.
+    """
+    harness.begin()
+    replan_nginx_mock = MagicMock()
+    monkeypatch.setattr(harness.charm.pebble_service, "replan_nginx", replan_nginx_mock)
+
+    harness.container_pebble_ready(synapse.SYNAPSE_NGINX_CONTAINER_NAME)
+
+    replan_nginx_mock.assert_called_once()
+    assert harness.model.unit.status == ops.MaintenanceStatus("Waiting for Synapse")


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
