### PR TITLE
Remove unused get_database_name function

### DIFF
--- a/src-docs/database_observer.py.md
+++ b/src-docs/database_observer.py.md
@@ -14,7 +14,7 @@ The Database relation observer.
 
 Attrs:  _pebble_service: instance of pebble service. 
 
-<a href="../src/database_observer.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/database_observer.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -41,31 +41,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/database_observer.py#L112"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `get_database_name`
-
-```python
-get_database_name() → str
-```
-
-Get database name. 
-
-
-
-**Raises:**
- 
- - <b>`CharmDatabaseRelationNotFoundError`</b>:  if there is no relation. 
-
-
-
-**Returns:**
- 
- - <b>`str`</b>:  database name. 
-
----
-
-<a href="../src/database_observer.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/database_observer.py#L89"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_relation_as_datasource`
 

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -17,7 +17,6 @@ from ops.framework import Object
 import synapse
 from charm_types import DatasourcePostgreSQL
 from database_client import DatabaseClient
-from exceptions import CharmDatabaseRelationNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -108,17 +107,3 @@ class DatabaseObserver(Object):
             port=endpoint.split(":")[1],
             db=self._charm.app.name,
         )
-
-    def get_database_name(self) -> str:
-        """Get database name.
-
-        Raises:
-            CharmDatabaseRelationNotFoundError: if there is no relation.
-
-        Returns:
-            str: database name.
-        """
-        datasource = self.get_relation_as_datasource()
-        if datasource is None:
-            raise CharmDatabaseRelationNotFoundError("No database relation was found.")
-        return datasource["db"]

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -18,7 +18,6 @@ import database_observer
 import synapse
 from charm_types import DatasourcePostgreSQL
 from database_client import DatabaseClient
-from exceptions import CharmDatabaseRelationNotFoundError
 
 
 @pytest.fixture(autouse=True)
@@ -196,29 +195,12 @@ def test_relation_as_datasource(
         user="user",
     )
     assert expected == harness.charm._database.get_relation_as_datasource()
-    assert harness.charm.app.name == harness.charm._database.get_database_name()
     synapse_env = synapse.get_environment(harness.charm._charm_state)
     assert synapse_env["POSTGRES_DB"] == expected["db"]
     assert synapse_env["POSTGRES_HOST"] == expected["host"]
     assert synapse_env["POSTGRES_PORT"] == expected["port"]
     assert synapse_env["POSTGRES_USER"] == expected["user"]
     assert synapse_env["POSTGRES_PASSWORD"] == expected["password"]
-
-
-def test_relation_as_datasource_error(harness: Harness, monkeypatch: pytest.MonkeyPatch):
-    """
-    arrange: start the Synapse charm, set Synapse container to be ready and set server_name.
-    act: add relation and trigger change config.
-    assert: charm status is active.
-    """
-    harness.begin()
-
-    get_relation_as_datasource_mock = unittest.mock.MagicMock(return_value=None)
-    monkeypatch.setattr(
-        harness.charm._database, "get_relation_as_datasource", get_relation_as_datasource_mock
-    )
-    with pytest.raises(CharmDatabaseRelationNotFoundError):
-        harness.charm._database.get_database_name()
 
 
 def test_change_config(harness: Harness):


### PR DESCRIPTION
### Overview

Remove an unused function and adapt the corresponding unit tests

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
