### PR TITLE
Refactor S3 Client for Backup

### DIFF
--- a/src-docs/backup.py.md
+++ b/src-docs/backup.py.md
@@ -6,28 +6,56 @@
 Provides backup functionality for Synapse. 
 
 
+
 ---
 
-<a href="../src/backup.py#L59"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+## <kbd>class</kbd> `S3Client`
+S3 Client Wrapper around boto3 library. 
 
-## <kbd>function</kbd> `can_use_bucket`
+<a href="../src/backup.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
 
 ```python
-can_use_bucket(s3_parameters: S3Parameters) → bool
+__init__(s3_parameters: S3Parameters)
+```
+
+Initialize the S3 client. 
+
+
+
+**Args:**
+ 
+ - <b>`s3_parameters`</b>:  Parameter to configure the S3 connection. 
+
+
+
+
+---
+
+<a href="../src/backup.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `can_use_bucket`
+
+```python
+can_use_bucket() → bool
 ```
 
 Check if a bucket exists and is accessible in an S3 compatible object store. 
 
 
 
-**Args:**
- 
- - <b>`s3_parameters`</b>:  S3 connection parameters 
-
-
-
 **Returns:**
- True if the bucket exists and is accessible 
+  True if the bucket exists and is accessible 
+
+
+---
+
+## <kbd>class</kbd> `S3Error`
+Generic S3 Exception. 
+
+
+
 
 
 ---
@@ -45,14 +73,21 @@ Configuration for accessing S3 bucket.
  - <b>`bucket`</b>:  The bucket name. 
  - <b>`endpoint`</b>:  The endpoint used to connect to the object storage. 
  - <b>`path`</b>:  The path inside the bucket to store objects. 
- - <b>`s3_uri_style`</b>:  The S3 protocol specific bucket path lookup type. 
+ - <b>`s3_uri_style`</b>:  The S3 protocol specific bucket path lookup type. Can be "path" or "host". 
+ - <b>`addressing_style`</b>:  S3 protocol addressing style, can be "path" or "virtual". 
 
+
+---
+
+#### <kbd>property</kbd> addressing_style
+
+Translates s3_uri_style to AWS addressing_style. 
 
 
 
 ---
 
-<a href="../src/backup.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_endpoint_or_region_set`
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -68,10 +68,6 @@ def inject_register_command_handler(monkeypatch: pytest.MonkeyPatch, harness: Ha
                 stderr=self._stderr,
             )
 
-        def wait(self):
-            """Simulate the wait method of the container object."""
-            self.wait_output()
-
     def exec_stub(command: list[str], **_kwargs):
         """A mock implementation of the `exec` method of the container object.
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,6 +16,7 @@ from charms.smtp_integrator.v0.smtp import AuthType, TransportSecurity
 from ops.pebble import ExecError
 from ops.testing import Harness
 
+import backup
 import synapse
 from charm import SynapseCharm
 
@@ -66,6 +67,10 @@ def inject_register_command_handler(monkeypatch: pytest.MonkeyPatch, harness: Ha
                 stdout=self._stdout,
                 stderr=self._stderr,
             )
+
+        def wait(self):
+            """Simulate the wait method of the container object."""
+            self.wait_output()
 
     def exec_stub(command: list[str], **_kwargs):
         """A mock implementation of the `exec` method of the container object.
@@ -238,3 +243,22 @@ def container_with_path_error_pass_fixture(
     remove_path_mock = unittest.mock.MagicMock(side_effect=path_error)
     monkeypatch.setattr(container_mocked, "remove_path", remove_path_mock)
     return container_mocked
+
+
+@pytest.fixture(name="s3_relation_data_backup")
+def s3_relation_data_backup_fixture() -> dict:
+    """Returns valid S3 relation data."""
+    return {
+        "access-key": token_hex(16),
+        "secret-key": token_hex(16),
+        "bucket": "synapse-backup-bucket",
+        "path": "/synapse-backups",
+        "s3-uri-style": "path",
+        "endpoint": "https://s3.example.com",
+    }
+
+
+@pytest.fixture(name="s3_parameters_backup")
+def s3_parameters_backup_fixture(s3_relation_data_backup) -> backup.S3Parameters:
+    """Returns valid S3 Parameters."""
+    return backup.S3Parameters(**s3_relation_data_backup)

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -108,7 +108,7 @@ def test_s3_relation_data_addressing_style(s3_relation_data, addressing_style):
     """
     arrange: Create s3 relation data with correct data.
     act: Create S3Parameters pydantic BaseModel from relation data.
-    assert: Check that the addressing style correspond to the expected ont.
+    assert: Check that the addressing style correspond to the expected value.
     """
     s3_parameters = backup.S3Parameters(**s3_relation_data)
     assert s3_parameters.addressing_style == addressing_style

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -3,12 +3,13 @@
 
 """Synapse backup unit tests."""
 
+# pylint: disable=protected-access
+
 from secrets import token_hex
 from unittest.mock import MagicMock
 
-import boto3
 import pytest
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import ClientError
 
 import backup
 
@@ -22,7 +23,7 @@ def test_s3_relation_validation_fails_when_region_and_endpoint_not_set():
     s3_relation_data = {
         "access-key": token_hex(16),
         "secret-key": token_hex(16),
-        "bucket": "synapse-backup-bucket",
+        "bucket": "backup-bucket",
         "path": "/synapse-backups",
         "s3-uri-style": "path",
     }
@@ -38,7 +39,7 @@ def test_s3_relation_validation_fails_when_region_and_endpoint_not_set():
             {
                 "access-key": token_hex(16),
                 "secret-key": token_hex(16),
-                "bucket": "synapse-backup-bucket",
+                "bucket": "backup-bucket",
                 "region": "us-west-2",
             },
             id="region defined but not endpoint",
@@ -47,8 +48,8 @@ def test_s3_relation_validation_fails_when_region_and_endpoint_not_set():
             {
                 "access-key": token_hex(16),
                 "secret-key": token_hex(16),
-                "bucket": "synapse-backup-bucket",
-                "endpoint": "https://example.com",
+                "bucket": "backup-bucket",
+                "endpoint": "https://s3.example.com",
             },
             id="endpoint defined but not region",
         ),
@@ -56,9 +57,9 @@ def test_s3_relation_validation_fails_when_region_and_endpoint_not_set():
             {
                 "access-key": token_hex(16),
                 "secret-key": token_hex(16),
-                "bucket": "synapse-backup-bucket",
+                "bucket": "backup-bucket",
                 "region": "us-west-2",
-                "endpoint": "https://example.com",
+                "endpoint": "https://s3.example.com",
             },
             id="both region and endpoint defined",
         ),
@@ -76,43 +77,89 @@ def test_s3_relation_validation_correct(s3_relation_data):
     assert s3_parameters.region == s3_relation_data.get("region")
 
 
-def test_can_use_bucket_wrong_boto3_resource(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "s3_relation_data, addressing_style",
+    [
+        pytest.param(
+            {
+                "access-key": token_hex(16),
+                "secret-key": token_hex(16),
+                "bucket": "backup-bucket",
+                "region": "us-west-2",
+                "s3-uri-style": "path",
+            },
+            "path",
+            id="uri style path",
+        ),
+        pytest.param(
+            {
+                "access-key": token_hex(16),
+                "secret-key": token_hex(16),
+                "bucket": "backup-bucket",
+                "region": "us-west-2",
+                "s3-uri-style": "host",
+            },
+            "virtual",
+            id="uri style host",
+        ),
+    ],
+)
+def test_s3_relation_data_addressing_style(s3_relation_data, addressing_style):
     """
-    arrange: Create S3Parameters and mock boto3 library so it raises on accessing S3 resource.
-    act: Run can_use_bucket.
-    assert: Check that the function returns False.
+    arrange: Create s3 relation data with correct data.
+    act: Create S3Parameters pydantic BaseModel from relation data.
+    assert: Check that the addressing style correspond to the expected ont.
     """
-    s3_parameters = backup.S3Parameters(
-        **{
-            "access-key": token_hex(16),
-            "secret-key": token_hex(16),
-            "region": "eu-west-1",
-            "bucket": "bucket_name",
-        }
-    )
-    session = MagicMock()
-    session.resource = MagicMock(side_effect=BotoCoreError())
-    monkeypatch.setattr(boto3.session, "Session", MagicMock(return_value=session))
-
-    assert not backup.can_use_bucket(s3_parameters)
+    s3_parameters = backup.S3Parameters(**s3_relation_data)
+    assert s3_parameters.addressing_style == addressing_style
 
 
-def test_can_use_bucket_bucket_error_checking_bucket(monkeypatch: pytest.MonkeyPatch):
+def test_s3_client_create_correct(s3_parameters_backup):
+    """
+    arrange: Create S3Parameters for the new client.
+    act: Create the new client.
+    assert: The client gets created correctly.
+    """
+    s3_client = backup.S3Client(s3_parameters_backup)
+
+    assert s3_client._client
+
+
+def test_s3_client_create_error(s3_parameters_backup):
+    """
+    arrange: Create S3Parameters for the new client.
+        Put access_key for the boto3 client to fail.
+    act: Create the new client.
+    assert: Raises S3Error.
+    """
+    s3_parameters_backup.access_key = None
+
+    with pytest.raises(backup.S3Error) as err:
+        backup.S3Client(s3_parameters_backup)
+    assert "Error creating S3 client" in str(err.value)
+
+
+def test_can_use_bucket_correct(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Create S3Parameters and mock boto3 client so it does not raise on head_bucket.
+    act: Run S3Client.can_use_bucket.
+    assert: Check that the function returns True.
+    """
+    s3_client = backup.S3Client(s3_parameters_backup)
+    monkeypatch.setattr(s3_client._client, "head_bucket", MagicMock())
+
+    assert s3_client.can_use_bucket()
+
+
+def test_can_use_bucket_bucket_error(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
     """
     arrange: Create S3Parameters and mock boto3 library so it fails when checking the bucket.
     act: Run can_use_bucket.
     assert: Check that the function returns False.
     """
-    s3_parameters = backup.S3Parameters(
-        **{
-            "access-key": token_hex(16),
-            "secret-key": token_hex(16),
-            "region": "eu-west-1",
-            "bucket": "bucket_name",
-        }
+    s3_client = backup.S3Client(s3_parameters_backup)
+    monkeypatch.setattr(
+        s3_client._client, "head_bucket", MagicMock(side_effect=ClientError({}, "HeadBucket"))
     )
-    session = MagicMock()
-    session.resource().Bucket().meta.client.head_bucket.side_effect = ClientError({}, "HeadBucket")
-    monkeypatch.setattr(boto3.session, "Session", MagicMock(return_value=session))
 
-    assert not backup.can_use_bucket(s3_parameters)
+    assert not s3_client.can_use_bucket()


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->
As a first step before the main [PR](https://github.com/canonical/synapse-operator/pull/171) for the backup action, the S3 interface is changed for the backup.

The interface for s3 now is just the function `can_use_bucket`. Other functions will be needed, like `list_objects`/`list_backups`, `delete_object`/`delete_backup`, and they will all use the same boto s3 client. A class is used to provide a simpler interface and will share the low level boto3 client. The other methods will be created in next PRs.

The low level client with S3 has been changed to use s3 client interface, as sometimes in the project (in the tests) the client interface was used and other times it was the resource interface.

Other some minor improvements have been made (use of the host/path property in S3 and putting tests in their correct directories)

### Rationale

<!-- The reason the change is needed -->
Split the main backup [PR](https://github.com/canonical/synapse-operator/pull/171) into manageable chunks.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
