### PR TITLE
Update tag names for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/matrix_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/matrix_bug_report.yml
@@ -1,6 +1,6 @@
 name: Matrix Deployment Bug Report
 description: Report a bug with the chat.ubuntu.com deployment
-labels: ["Type: Bug", "Status: Triage", "Context: deployment"]
+labels: ["Type: Bug", "Status: Triage", "Context: Deployment"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/matrix_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/matrix_enhancement.yml
@@ -1,6 +1,6 @@
 name: Matrix Deployment Enhancement
 description: Suggest a feature for the chat.ubuntu.com deployment
-labels: ["Type: Enhancement", "Status: Triage", "deployment"]
+labels: ["Type: Enhancement", "Status: Triage", "Context: Deployment"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
@amandahla I was inconsistent with the tag names and was now wondering why we have two different ones. Can you merge this, and change the "Context: deployment" tag to "Context: Deployment", and move all issues with the "deployment" tag to "Context: Deployment"?