### PR TITLE
chore(pytest): Add custom markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-markers = ["requires_secrets: mark tests that require external secrets"]
+markers = [
+    "requires_secrets: mark tests that require external secrets",
+    "cos: mark tests that require a COS integration",
+    "nginx: mark tests that require an nginx integration",
+    "s3: mark tests that require an s3 integration (via localstack)"
+]
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -545,6 +545,7 @@ async def test_anonymize_user(
     assert res.status_code == 403
 
 
+@pytest.mark.s3
 @pytest.mark.usefixtures("s3_backup_bucket")
 async def test_synapse_enable_s3_backup_integration_success(
     model: Model,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Adds custom pytest markers to the `pyproject.toml`.
<!-- A high level overview of the change -->

### Rationale

pytest complains on tests that the markers are not defined.
<!-- The reason the change is needed -->

### Juju Events Changes

n/a
<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

Added an additional `s3` marker in the integration tests if you want to skip the s3 localstack tests.
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

n/a
<!-- Any changes to charm libraries -->

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
