### PR TITLE
List backups action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -44,3 +44,6 @@ promote-user-admin:
 create-backup:
   description: |
     Creates a backup to s3 storage.
+list-backups:
+  description: |
+    Lists backups in s3 storage.

--- a/src-docs/backup.py.md
+++ b/src-docs/backup.py.md
@@ -17,7 +17,7 @@ Provides backup functionality for Synapse.
 
 ---
 
-<a href="../src/backup.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_backup`
 
@@ -106,7 +106,7 @@ Initialize the S3 client.
 
 ---
 
-<a href="../src/backup.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `can_use_bucket`
 
@@ -123,7 +123,7 @@ Check if a bucket exists and is accessible in an S3 compatible object store.
 
 ---
 
-<a href="../src/backup.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L185"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `list_backups`
 
@@ -137,12 +137,6 @@ List the backups stored in S3 in the current s3 configuration.
 
 **Returns:**
   list of backups. 
-
-
-
-**Raises:**
- 
- - <b>`S3Error`</b>:  if listing the objects in S3 fails. 
 
 
 ---

--- a/src-docs/backup.py.md
+++ b/src-docs/backup.py.md
@@ -17,7 +17,7 @@ Provides backup functionality for Synapse.
 
 ---
 
-<a href="../src/backup.py#L165"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_backup`
 
@@ -62,10 +62,30 @@ Generic backup Exception.
 
 ---
 
+## <kbd>class</kbd> `S3Backup`
+Information about a backup file from S3. 
+
+
+
+**Attributes:**
+ 
+ - <b>`backup_id`</b>:  backup id 
+ - <b>`etag`</b>:  etag in S3 
+ - <b>`last_modified`</b>:  last modified date in S3 
+ - <b>`prefix`</b>:  prefix of the object ky 
+ - <b>`s3_object_key`</b>:  full object key 
+ - <b>`size`</b>:  size in bytes 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `S3Client`
 S3 Client Wrapper around boto3 library. 
 
-<a href="../src/backup.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -86,7 +106,7 @@ Initialize the S3 client.
 
 ---
 
-<a href="../src/backup.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `can_use_bucket`
 
@@ -100,6 +120,29 @@ Check if a bucket exists and is accessible in an S3 compatible object store.
 
 **Returns:**
   True if the bucket exists and is accessible 
+
+---
+
+<a href="../src/backup.py#L184"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `list_backups`
+
+```python
+list_backups() → List[S3Backup]
+```
+
+List the backups stored in S3 in the current s3 configuration. 
+
+
+
+**Returns:**
+  list of backups. 
+
+
+
+**Raises:**
+ 
+ - <b>`S3Error`</b>:  if listing the objects in S3 fails. 
 
 
 ---

--- a/src-docs/backup.py.md
+++ b/src-docs/backup.py.md
@@ -125,7 +125,7 @@ Check if a bucket exists and is accessible in an S3 compatible object store.
 ### <kbd>function</kbd> `list_backups`
 
 ```python
-list_backups() → List[S3Backup]
+list_backups() → list[S3Backup]
 ```
 
 List the backups stored in S3 in the current s3 configuration. 

--- a/src-docs/backup.py.md
+++ b/src-docs/backup.py.md
@@ -17,7 +17,7 @@ Provides backup functionality for Synapse.
 
 ---
 
-<a href="../src/backup.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_backup`
 
@@ -70,10 +70,7 @@ Information about a backup file from S3.
 **Attributes:**
  
  - <b>`backup_id`</b>:  backup id 
- - <b>`etag`</b>:  etag in S3 
  - <b>`last_modified`</b>:  last modified date in S3 
- - <b>`prefix`</b>:  prefix of the object ky 
- - <b>`s3_object_key`</b>:  full object key 
  - <b>`size`</b>:  size in bytes 
 
 
@@ -85,7 +82,7 @@ Information about a backup file from S3.
 ## <kbd>class</kbd> `S3Client`
 S3 Client Wrapper around boto3 library. 
 
-<a href="../src/backup.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -106,7 +103,7 @@ Initialize the S3 client.
 
 ---
 
-<a href="../src/backup.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `can_use_bucket`
 
@@ -123,7 +120,7 @@ Check if a bucket exists and is accessible in an S3 compatible object store.
 
 ---
 
-<a href="../src/backup.py#L185"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `list_backups`
 

--- a/src-docs/backup_observer.py.md
+++ b/src-docs/backup_observer.py.md
@@ -16,7 +16,7 @@ S3 Backup relation observer for Synapse.
 ## <kbd>class</kbd> `BackupObserver`
 The S3 backup relation observer. 
 
-<a href="../src/backup_observer.py#L28"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup_observer.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/backup_observer.py.md
+++ b/src-docs/backup_observer.py.md
@@ -16,7 +16,7 @@ S3 Backup relation observer for Synapse.
 ## <kbd>class</kbd> `BackupObserver`
 The S3 backup relation observer. 
 
-<a href="../src/backup_observer.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/backup_observer.py#L28"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src/backup.py
+++ b/src/backup.py
@@ -183,9 +183,9 @@ class S3Client:
             list of backups.
         """
         backups = []
-        for item in self._iterate_objects():
+        for item in self._list_s3_objects():
             s3_object_key = pathlib.Path(item["Key"])
-            backup_id = (s3_object_key).relative_to(self._prefix)
+            backup_id = s3_object_key.relative_to(self._prefix)
             backup = S3Backup(
                 backup_id=str(backup_id),
                 last_modified=item["LastModified"],
@@ -194,7 +194,7 @@ class S3Client:
             backups.append(backup)
         return backups
 
-    def _iterate_objects(self) -> Generator[dict, None, None]:
+    def _list_s3_objects(self) -> Generator[dict, None, None]:
         """List the backups stored in S3 in the current s3 configuration.
 
         A paginator is used over `list_objects_v2` because there can

--- a/src/backup.py
+++ b/src/backup.py
@@ -7,7 +7,7 @@ import datetime
 import logging
 import os
 import pathlib
-from typing import Any, Dict, Generator, Iterable, List, NamedTuple, Optional
+from typing import Any, Dict, Generator, Iterable, NamedTuple, Optional
 
 import boto3
 import ops
@@ -379,7 +379,7 @@ def _build_backup_command(
     backup_paths: Iterable[str],
     passphrase_file: str,
     expected_size: int,
-) -> List[str]:
+) -> list[str]:
     """Build the command to execute the backup.
 
     Args:

--- a/src/backup.py
+++ b/src/backup.py
@@ -176,7 +176,7 @@ class S3Client:
             return False
         return True
 
-    def list_backups(self) -> List[S3Backup]:
+    def list_backups(self) -> list[S3Backup]:
         """List the backups stored in S3 in the current s3 configuration.
 
         Returns:

--- a/src/backup.py
+++ b/src/backup.py
@@ -106,18 +106,12 @@ class S3Backup(NamedTuple):
 
     Attributes:
         backup_id: backup id
-        etag: etag in S3
         last_modified: last modified date in S3
-        prefix: prefix of the object ky
-        s3_object_key: full object key
         size: size in bytes
     """
 
     backup_id: str
-    etag: str
     last_modified: datetime.datetime
-    prefix: str
-    s3_object_key: str
     size: int
 
 
@@ -194,11 +188,8 @@ class S3Client:
             backup_id = (s3_object_key).relative_to(self._prefix)
             backup = S3Backup(
                 backup_id=str(backup_id),
-                s3_object_key=str(s3_object_key),
-                prefix=self._prefix,
                 last_modified=item["LastModified"],
                 size=item["Size"],
-                etag=item["ETag"],
             )
             backups.append(backup)
         return backups

--- a/src/backup_observer.py
+++ b/src/backup_observer.py
@@ -133,8 +133,8 @@ class BackupObserver(Object):
             s3_client = backup.S3Client(s3_parameters)
             backups = s3_client.list_backups()
         except backup.S3Error:
-            logger.exception("Error while trying looking for backups.")
-            self._charm.unit.status = ops.BlockedStatus(S3_CANNOT_ACCESS_BUCKET)
+            logger.exception("Error listing backups.")
+            event.fail("Error listing backups.")
             return
 
         event.set_results(

--- a/src/backup_observer.py
+++ b/src/backup_observer.py
@@ -101,10 +101,10 @@ class BackupObserver(Object):
         """Generate a formatted string for the backups.
 
         Args:
-            backup_list: List of backups to create a formatted string for
+            backup_list: List of backups to create a formatted string for.
 
         Returns:
-            The formatted string of the backups
+            The formatted string of the backups.
         """
         output = [f"{'backup-id':<29s} | {'last-modified':<28s} | {'size':>15s}"]
         output.append("-" * len(output[0]))

--- a/src/backup_observer.py
+++ b/src/backup_observer.py
@@ -97,7 +97,7 @@ class BackupObserver(Object):
 
         event.set_results({"result": "correct", "backup-id": backup_id})
 
-    def _generate_backup_list_formatted(self, backup_list: typing.List[backup.S3Backup]) -> str:
+    def _generate_backup_list_formatted(self, backup_list: list[backup.S3Backup]) -> str:
         """Generate a formatted string for the backups.
 
         Args:

--- a/src/backup_observer.py
+++ b/src/backup_observer.py
@@ -4,7 +4,6 @@
 """S3 Backup relation observer for Synapse."""
 
 import logging
-import typing
 
 import ops
 from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer

--- a/src/backup_observer.py
+++ b/src/backup_observer.py
@@ -4,6 +4,7 @@
 """S3 Backup relation observer for Synapse."""
 
 import logging
+import typing
 
 import ops
 from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
@@ -40,6 +41,7 @@ class BackupObserver(Object):
         )
         self.framework.observe(self._s3_client.on.credentials_gone, self._on_s3_credential_gone)
         self.framework.observe(self._charm.on.create_backup_action, self._on_create_backup_action)
+        self.framework.observe(self._charm.on.list_backups_action, self._on_list_backups_action)
 
     def _on_s3_credential_changed(self, _: CredentialsChangedEvent) -> None:
         """Check new S3 credentials set the unit to blocked if they are wrong."""
@@ -94,3 +96,56 @@ class BackupObserver(Object):
             return
 
         event.set_results({"result": "correct", "backup-id": backup_id})
+
+    def _generate_backup_list_formatted(self, backup_list: typing.List[backup.S3Backup]) -> str:
+        """Generate a formatted string for the backups.
+
+        Args:
+            backup_list: List of backups to create a formatted string for
+
+        Returns:
+            The formatted string of the backups
+        """
+        output = [f"{'backup-id':<29s} | {'last-modified':<28s} | {'size':>15s}"]
+        output.append("-" * len(output[0]))
+        for cur_backup in backup_list:
+            output.append(
+                f"{cur_backup.backup_id:<29s}"
+                f" | {cur_backup.last_modified!s:<28s}"
+                f" | {cur_backup.size:>15d}"
+            )
+        return "\n".join(output)
+
+    def _on_list_backups_action(self, event: ActionEvent) -> None:
+        """List backups in S3 configured storage.
+
+        Args:
+            event: Event triggering the list backups action.
+        """
+        try:
+            s3_parameters = backup.S3Parameters(**self._s3_client.get_s3_connection_info())
+        except ValueError:
+            logger.exception("Wrong S3 configuration in list backups action")
+            event.fail("Wrong S3 configuration on list backups action. Check S3 integration.")
+            return
+
+        try:
+            s3_client = backup.S3Client(s3_parameters)
+            backups = s3_client.list_backups()
+        except backup.S3Error:
+            logger.exception("Error while trying looking for backups.")
+            self._charm.unit.status = ops.BlockedStatus(S3_CANNOT_ACCESS_BUCKET)
+            return
+
+        event.set_results(
+            {
+                "formatted": self._generate_backup_list_formatted(backups),
+                "backups": {
+                    backup.backup_id: {
+                        "last-modified": str(backup.last_modified),
+                        "size": str(backup.size),
+                    }
+                    for backup in backups
+                },
+            }
+        )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -663,7 +663,7 @@ async def test_synapse_list_backups(
     """
     arrange: Synapse App deployed and related with s3-integrator. Set backup_passphrase
         and create two backups.
-    act: $un action list-backups
+    act: Run action list-backups
     assert: There should be two backups, with the same keys as the ones created.
     """
     await model.add_relation(s3_integrator_app_backup.name, f"{synapse_app.name}:backup")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -651,3 +651,41 @@ async def test_synapse_create_backup_no_passphrase(
     assert backup_action.status == "failed"
     assert "backup-id" not in backup_action.results
     assert "Missing backup_passphrase" in backup_action.message
+
+
+@pytest.mark.s3
+@pytest.mark.usefixtures("s3_backup_bucket")
+async def test_synapse_list_backups(
+    model: Model,
+    synapse_app: Application,
+    s3_integrator_app_backup: Application,
+):
+    """
+    arrange: Synapse App deployed and related with s3-integrator. Set backup_passphrase
+        and create two backups.
+    act: $un action list-backups
+    assert: There should be two backups, with the same keys as the ones created.
+    """
+    await model.add_relation(s3_integrator_app_backup.name, f"{synapse_app.name}:backup")
+    passphrase = token_hex(16)
+    await synapse_app.set_config({"backup_passphrase": passphrase})
+    await model.wait_for_idle(
+        idle_period=30,
+        apps=[synapse_app.name, s3_integrator_app_backup.name],
+        status=ACTIVE_STATUS_NAME,
+    )
+    synapse_unit: Unit = next(iter(synapse_app.units))
+    backup_action_1: Action = await synapse_unit.run_action("create-backup")
+    await backup_action_1.wait()
+    backup_action_2: Action = await synapse_unit.run_action("create-backup")
+    await backup_action_2.wait()
+
+    list_backups_action: Action = await synapse_unit.run_action("list-backups")
+    await list_backups_action.wait()
+
+    assert list_backups_action.status == "completed"
+    assert "backups" in list_backups_action.results
+    backups = list_backups_action.results["backups"]
+    assert len(backups) == 2
+    assert backup_action_1.results["backup-id"] in backups
+    assert backup_action_2.results["backup-id"] in backups

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -214,18 +214,12 @@ def test_list_backups_correct(s3_parameters_backup, monkeypatch: pytest.MonkeyPa
     assert backups == [
         backup.S3Backup(
             backup_id="20240201122721",
-            etag='"ed4a010045db523f7adc1ddc19e26971"',
             last_modified=datetime.datetime(2024, 2, 1, 12, 27, 23, 749000, tzinfo=tzutc()),
-            prefix="synapse-backups",
-            s3_object_key="synapse-backups/20240201122721",
             size=38296,
         ),
         backup.S3Backup(
             backup_id="20240201122942",
-            etag='"200e44b3b6e4c1e98b1a902e5260b9be"',
             last_modified=datetime.datetime(2024, 2, 1, 12, 29, 43, 804000, tzinfo=tzutc()),
-            prefix="synapse-backups",
-            s3_object_key="synapse-backups/20240201122942",
             size=50000,
         ),
     ]
@@ -269,10 +263,7 @@ def test_list_backups_correct_no_root_slash(s3_parameters_backup, monkeypatch: p
     assert backups == [
         backup.S3Backup(
             backup_id="20240201122942",
-            etag='"200e44b3b6e4c1e98b1a902e5260b9be"',
             last_modified=datetime.datetime(2024, 2, 1, 12, 29, 43, 804000, tzinfo=tzutc()),
-            prefix="synapse-backups",
-            s3_object_key="synapse-backups/20240201122942",
             size=50000,
         ),
     ]

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -174,8 +174,8 @@ def test_can_use_bucket_bucket_error(s3_parameters_backup, monkeypatch: pytest.M
 
 def test_list_backups_correct(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: Create a S3Client. Mock response to return a real one in list_backups.
-    act: run list_backups.
+    arrange: Create a S3Client. Mock response to return a real response in list_objects_v2.
+    act: Run list_backups.
     assert: The expected list of backups is correctly parsed.
     """
     s3_client = backup.S3Client(s3_parameters_backup)
@@ -227,9 +227,9 @@ def test_list_backups_correct(s3_parameters_backup, monkeypatch: pytest.MonkeyPa
 
 def test_list_backups_correct_no_root_slash(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: Create a S3Client. Mock response to return a real one in list_backups with Keys
-        without root slash as returned by MinIO even when created with them.
-    act: run list_backups.
+    arrange: Create a S3Client. Mock response to return a real response in list_objects_v2 with
+        Keys without root slash as returned by MinIO even when created with them.
+    act: Run list_backups.
     assert: The expected list of backups is correctly parsed.
     """
     s3_parameters_backup.path = s3_parameters_backup.path.strip("/")
@@ -271,8 +271,8 @@ def test_list_backups_correct_no_root_slash(s3_parameters_backup, monkeypatch: p
 
 def test_list_backups_empty(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: Create a S3Client. Mock response to return a real one in list_backups without backups.
-    act: run list_backups.
+    arrange: Create a S3Client. Mock response to return a real empty response in list_objects_v2.
+    act: Run list_backups.
     assert: The expected list of backups is correctly parsed.
     """
     s3_client = backup.S3Client(s3_parameters_backup)
@@ -299,8 +299,8 @@ def test_list_backups_empty(s3_parameters_backup, monkeypatch: pytest.MonkeyPatc
 
 def test_list_backups_error(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: Create a S3Client. Mock response to raise a ClienError Exception.
-    act: run list_backups.
+    arrange: Create a S3Client. Mock response to raise a ClientError Exception.
+    act: Run list_backups.
     assert: A S3Error should be raised.
     """
     s3_client = backup.S3Client(s3_parameters_backup)

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -228,7 +228,7 @@ def test_list_backups_correct(s3_parameters_backup, monkeypatch: pytest.MonkeyPa
 def test_list_backups_correct_no_root_slash(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
     """
     arrange: Create a S3Client. Mock response to return a real response in list_objects_v2 with
-        Keys without root slash as returned by MinIO even when created with them.
+        Keys without root slash as returned by MinIO even when created with root slash.
     act: Run list_backups.
     assert: The expected list of backups is correctly parsed.
     """

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -318,7 +318,7 @@ def test_list_backups_error(s3_parameters_backup, monkeypatch: pytest.MonkeyPatc
 
     with pytest.raises(backup.S3Error) as err:
         s3_client.list_backups()
-    assert "Error listing" in str(err.value)
+    assert "Error iterating" in str(err.value)
 
 
 def test_create_backup_correct(

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=protected-access
 
+import datetime
 import os
 import pathlib
 from secrets import token_hex
@@ -13,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 import yaml
 from botocore.exceptions import ClientError
+from dateutil.tz import tzutc  # type: ignore
 from ops.testing import Harness
 
 import backup
@@ -168,6 +170,155 @@ def test_can_use_bucket_bucket_error(s3_parameters_backup, monkeypatch: pytest.M
     )
 
     assert not s3_client.can_use_bucket()
+
+
+def test_list_backups_correct(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Create a S3Client. Mock response to return a real one in list_backups.
+    act: run list_backups.
+    assert: The expected list of backups is correctly parsed.
+    """
+    s3_client = backup.S3Client(s3_parameters_backup)
+    s3_example_response = {
+        "ResponseMetadata": {
+            "RequestId": "17AFBDF4A3306A4F",
+            "HostId": "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8",
+            "HTTPStatusCode": 200,
+        },
+        "IsTruncated": False,
+        "Contents": [
+            {
+                "Key": "synapse-backups/20240201122721",
+                "LastModified": datetime.datetime(2024, 2, 1, 12, 27, 23, 749000, tzinfo=tzutc()),
+                "ETag": '"ed4a010045db523f7adc1ddc19e26971"',
+                "Size": 38296,
+            },
+            {
+                "Key": "synapse-backups/20240201122942",
+                "LastModified": datetime.datetime(2024, 2, 1, 12, 29, 43, 804000, tzinfo=tzutc()),
+                "ETag": '"200e44b3b6e4c1e98b1a902e5260b9be"',
+                "Size": 50000,
+            },
+        ],
+        "Name": "backups-bucket",
+        "Prefix": "synapse-backups",
+        "MaxKeys": 1000,
+        "EncodingType": "url",
+        "KeyCount": 2,
+    }
+    list_objects_v2_mock = MagicMock(return_value=s3_example_response)
+    monkeypatch.setattr(s3_client._client, "list_objects_v2", list_objects_v2_mock)
+
+    backups = s3_client.list_backups()
+
+    assert backups == [
+        backup.S3Backup(
+            backup_id="20240201122721",
+            etag='"ed4a010045db523f7adc1ddc19e26971"',
+            last_modified=datetime.datetime(2024, 2, 1, 12, 27, 23, 749000, tzinfo=tzutc()),
+            prefix="synapse-backups",
+            s3_object_key="synapse-backups/20240201122721",
+            size=38296,
+        ),
+        backup.S3Backup(
+            backup_id="20240201122942",
+            etag='"200e44b3b6e4c1e98b1a902e5260b9be"',
+            last_modified=datetime.datetime(2024, 2, 1, 12, 29, 43, 804000, tzinfo=tzutc()),
+            prefix="synapse-backups",
+            s3_object_key="synapse-backups/20240201122942",
+            size=50000,
+        ),
+    ]
+
+
+def test_list_backups_correct_no_root_slash(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Create a S3Client. Mock response to return a real one in list_backups with Keys
+        without root slash as returned by MinIO even when created with them.
+    act: run list_backups.
+    assert: The expected list of backups is correctly parsed.
+    """
+    s3_parameters_backup.path = s3_parameters_backup.path.strip("/")
+    s3_client = backup.S3Client(s3_parameters_backup)
+    s3_example_response = {
+        "ResponseMetadata": {
+            "RequestId": "17AFBDF4A3306A4F",
+            "HostId": "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8",
+            "HTTPStatusCode": 200,
+        },
+        "IsTruncated": False,
+        "Contents": [
+            {
+                "Key": "synapse-backups/20240201122942",
+                "LastModified": datetime.datetime(2024, 2, 1, 12, 29, 43, 804000, tzinfo=tzutc()),
+                "ETag": '"200e44b3b6e4c1e98b1a902e5260b9be"',
+                "Size": 50000,
+            },
+        ],
+        "Name": "backups-bucket",
+        "Prefix": "synapse-backups/",
+        "MaxKeys": 1000,
+        "EncodingType": "url",
+        "KeyCount": 2,
+    }
+    list_objects_v2_mock = MagicMock(return_value=s3_example_response)
+    monkeypatch.setattr(s3_client._client, "list_objects_v2", list_objects_v2_mock)
+
+    backups = s3_client.list_backups()
+
+    assert backups == [
+        backup.S3Backup(
+            backup_id="20240201122942",
+            etag='"200e44b3b6e4c1e98b1a902e5260b9be"',
+            last_modified=datetime.datetime(2024, 2, 1, 12, 29, 43, 804000, tzinfo=tzutc()),
+            prefix="synapse-backups",
+            s3_object_key="synapse-backups/20240201122942",
+            size=50000,
+        ),
+    ]
+
+
+def test_list_backups_empty(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Create a S3Client. Mock response to return a real one in list_backups without backups.
+    act: run list_backups.
+    assert: The expected list of backups is correctly parsed.
+    """
+    s3_client = backup.S3Client(s3_parameters_backup)
+    s3_example_response = {
+        "ResponseMetadata": {
+            "RequestId": "17AFBDF4A3306A4F",
+            "HostId": "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8",
+            "HTTPStatusCode": 200,
+        },
+        "IsTruncated": False,
+        "Name": "backups-bucket",
+        "Prefix": "synapse",
+        "MaxKeys": 1000,
+        "EncodingType": "url",
+        "KeyCount": 0,
+    }
+    list_objects_v2_mock = MagicMock(return_value=s3_example_response)
+    monkeypatch.setattr(s3_client._client, "list_objects_v2", list_objects_v2_mock)
+
+    backups = s3_client.list_backups()
+
+    assert not backups
+
+
+def test_list_backups_error(s3_parameters_backup, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Create a S3Client. Mock response to raise a ClienError Exception.
+    act: run list_backups.
+    assert: A S3Error should be raised.
+    """
+    s3_client = backup.S3Client(s3_parameters_backup)
+    list_objects_v2_mock = MagicMock(side_effect=ClientError({}, "No Such Bucket"))
+    monkeypatch.setattr(s3_client._client, "list_objects_v2", list_objects_v2_mock)
+
+    with pytest.raises(backup.S3Error) as err:
+        s3_client.list_backups()
+    assert "Error listing" in str(err.value)
 
 
 def test_create_backup_correct(

--- a/tests/unit/test_backup_observer.py
+++ b/tests/unit/test_backup_observer.py
@@ -211,18 +211,12 @@ def test_list_backups_correct(
     backups = [
         backup.S3Backup(
             backup_id="202301311259",
-            etag="",
             last_modified=datetime.datetime(2024, 1, 1, 0, 0, 0),
-            prefix="",
-            s3_object_key="",
             size=1_000_000_000_000,
         ),
         backup.S3Backup(
             backup_id="202401311259",
-            etag="",
             last_modified=datetime.datetime(2024, 2, 1, 0, 0, 0),
-            prefix="",
-            s3_object_key="",
             size=20_000_000_000_000,
         ),
     ]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->
Applicable spec: ISD095


### Overview

<!-- A high level overview of the change -->
This PR creates the action `list-backups` action in Synapse. 

The backups created with the action `create-backup` will be created in a specific prefix in the S3 repository, and they will be read and listed by this action, with some extra information. Its output will be like this:

```
juju run synapse/leader list-backups
Running operation 51 with 1 task
  - task 52 on unit-synapse-0

Waiting for task 52...
backups:
  backup-20240206100503602202:
    last-modified: 2024-02-06 10:05:05.945000+00:00
    size: "40699"
  backup-20240206152530632850:
    last-modified: 2024-02-06 15:25:33.826000+00:00
    size: "40698"
  backup-20240206152707269036:
    last-modified: 2024-02-06 15:27:09.728000+00:00
    size: "40699"
  backup-20240207074717616279:
    last-modified: 2024-02-07 07:47:18.803000+00:00
    size: "40699"
formatted: |-
  backup-id                     | last-modified                |            size
  ------------------------------------------------------------------------------
  backup-20240206100503602202   | 2024-02-06 10:05:05.945000+00:00 |           40699
  backup-20240206152530632850   | 2024-02-06 15:25:33.826000+00:00 |           40698
  backup-20240206152707269036   | 2024-02-06 15:27:09.728000+00:00 |           40699
  backup-20240207074717616279   | 2024-02-07 07:47:18.803000+00:00 |           40699
```

`list-backups` will iterate over the objects in S3 at the given path. As elements will not be retrieved and checked, if a 
`fake` backup is put in S3 in that path, it will be listed.
 
### Rationale

<!-- The reason the change is needed -->
This new action is part of the disaster and recovery purposes related to backups.


### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

Added `list-backups` action. Added new observer in `backup_observer` and logic to query S3 in `backup` module.

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
