### PR TITLE
Update synapse/poetry versions, pin version for the rust toolchain

### DIFF
--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -82,7 +82,7 @@ parts:
             - mjolnir/latest/edge
             - matrix-appservice-irc/latest/edge
         plugin: nil
-        source: https://github.com/matrix-org/synapse/
+        source: https://github.com/element-hq/synapse/
         source-type: git
         source-tag: v1.101.0
         override-build: |

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -85,6 +85,9 @@ parts:
         source: https://github.com/element-hq/synapse/
         source-type: git
         source-tag: v1.101.0
+        build-environment:
+          - RUST_VERSION: "1.76.0"
+          - POETRY_VERSION: "1.7.1"
         override-build: |
             craftctl default
             export RUSTUP_HOME=/rust
@@ -92,10 +95,10 @@ parts:
             export PATH=/cargo/bin:/rust/bin:$PATH
             export CARGO_NET_GIT_FETCH_WITH_CLI=false
             mkdir -p /rust /cargo /synapse /install
-            curl -m 30 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain=1.76.0 --profile minimal
-            /rust/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc -V > $CRAFT_PART_INSTALL/rust-version
+            curl -m 30 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain=$RUST_VERSION --profile minimal
+            /rust/toolchains/$RUST_VERSION-x86_64-unknown-linux-gnu/bin/rustc -V > $CRAFT_PART_INSTALL/rust-version
             pip3 install -U pip setuptools
-            pip3 install --root-user-action=ignore "poetry==1.7.1"
+            pip3 install --root-user-action=ignore "poetry==$POETRY_VERSION"
             cp pyproject.toml poetry.lock /synapse/
             /usr/local/bin/poetry export --extras all -o /synapse/requirements.txt
             pip3 install --prefix="/install" --no-deps --no-warn-script-location -r /synapse/requirements.txt

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -84,7 +84,7 @@ parts:
         plugin: nil
         source: https://github.com/matrix-org/synapse/
         source-type: git
-        source-tag: v1.96.1
+        source-tag: v1.101.0
         override-build: |
             craftctl default
             export RUSTUP_HOME=/rust
@@ -92,10 +92,10 @@ parts:
             export PATH=/cargo/bin:/rust/bin:$PATH
             export CARGO_NET_GIT_FETCH_WITH_CLI=false
             mkdir -p /rust /cargo /synapse /install
-            curl -m 30 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain stable --profile minimal
+            curl -m 30 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain=1.76.0 --profile minimal
             /rust/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc -V > $CRAFT_PART_INSTALL/rust-version
             pip3 install -U pip setuptools
-            pip3 install --root-user-action=ignore "poetry==1.3.2"
+            pip3 install --root-user-action=ignore "poetry==1.7.1"
             cp pyproject.toml poetry.lock /synapse/
             /usr/local/bin/poetry export --extras all -o /synapse/requirements.txt
             pip3 install --prefix="/install" --no-deps --no-warn-script-location -r /synapse/requirements.txt


### PR DESCRIPTION
### Overview

- Update synapse to 1.101.0
- Update poetry to 1.7.1
- Pin version for the rust toolchain to 1.76.0

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
