### PR TITLE
Add Redis configuration when integrating with Redis charm

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,4 +13,4 @@ jobs:
       trivy-image-config: "trivy.yaml"
       juju-channel: 3.1/stable
       channel: 1.28-strict/stable
-      modules: '["test_charm", "test_nginx", "test_s3"]'
+      modules: '["test_charm", "test_nginx", "test_s3", "test_redis"]'

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -1,5 +1,18 @@
 # Integrations
 
+### backup
+
+_Interface_: s3
+_Supported charms_: [s3-integrator](https://charmhub.io/s3-integrator/)
+
+In order to perform backups, Synapse has to be integrated with the s3-integrator charm using the
+endpoint backup. Backups will be stored, listed and recovered from the location
+indicated in the S3 compatible object storage provider configuration provided by the integration.
+The Synapse charm will back up the media files, signing keys and sqlite database file if applicable.
+If Synapse database integration is used, the Synapse charm will not back up the related database.
+
+Example backup integrate command: `juju integrate synapse:backup s3-integrator`
+
 ### db
 
 _Interface_: pgsql
@@ -59,6 +72,17 @@ relation becomes active. For more information about the metrics exposed, refer t
 
 Metrics-endpoint integrate command: `juju integrate synapse prometheus-k8s`
 
+### redis
+
+_Interface_: redis
+_Supported charms_: [redis-k8s](https://charmhub.io/redis-k8s)
+
+Integrating Synapse with Redis is required by horizontal scaling the charm.
+
+See more information in [Scaling synapse via workers](https://matrix-org.github.io/synapse/latest/workers.html) in documentation repository for Synapse.
+
+Example redis integrate command: `juju integrate synapse redis-k8s`
+
 ### saml
 
 _Interface_: saml
@@ -94,17 +118,3 @@ For the smtp-integrator, insecure configurations with `transport_security=none` 
 authenticated connections with `auth_type=none` are not supported.
 
 See more information in [Charm Architecture](https://charmhub.io/synapse/docs/explanation-charm-architecture).
-
-
-### backup
-
-_Interface_: s3
-_Supported charms_: [s3-integrator](https://charmhub.io/s3-integrator/)
-
-In order to perform backups, Synapse has to be integrated with the s3-integrator charm using the
-endpoint backup. Backups will be stored, listed and recovered from the location
-indicated in the S3 compatible object storage provider configuration provided by the integration.
-The Synapse charm will back up the media files, signing keys and sqlite database file if applicable.
-If Synapse database integration is used, the Synapse charm will not back up the related database.
-
-Example backup integrate command: `juju integrate synapse:backup s3-integrator`

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -69,7 +69,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -12,7 +12,9 @@ Charm for Synapse on kubernetes.
 ## <kbd>class</kbd> `SynapseCharm`
 Charm the service. 
 
-<a href="../src/charm.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+Attrs:  on: listen to Redis events. 
+
+<a href="../src/charm.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -69,7 +71,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L108"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -14,7 +14,7 @@ Exception raised when a charm configuration is found to be invalid.
 
 Attrs:  msg (str): Explanation of the error. 
 
-<a href="../src/charm_state.py#L33"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -47,6 +47,7 @@ State of the Charm.
  - <b>`datasource`</b>:  datasource information. 
  - <b>`saml_config`</b>:  saml configuration. 
  - <b>`smtp_config`</b>:  smtp configuration. 
+ - <b>`redis_config`</b>:  redis configuration. 
  - <b>`proxy`</b>:  proxy information. 
 
 
@@ -65,7 +66,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L164"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -74,7 +75,8 @@ from_charm(
     charm: CharmBase,
     datasource: Optional[DatasourcePostgreSQL],
     saml_config: Optional[SAMLConfiguration],
-    smtp_config: Optional[SMTPConfiguration]
+    smtp_config: Optional[SMTPConfiguration],
+    redis_config: Optional[RedisConfiguration]
 ) → CharmState
 ```
 
@@ -88,6 +90,7 @@ Initialize a new instance of the CharmState class from the associated charm.
  - <b>`datasource`</b>:  datasource information to be used by Synapse. 
  - <b>`saml_config`</b>:  saml configuration to be used by Synapse. 
  - <b>`smtp_config`</b>:  SMTP configuration to be used by Synapse. 
+ - <b>`redis_config`</b>:  Redis configuration to be used by Synapse. 
 
 Return: The CharmState instance created by the provided charm. 
 
@@ -141,7 +144,7 @@ Represent Synapse builtin configuration values.
 
 ---
 
-<a href="../src/charm_state.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `get_default_notif_from`
 
@@ -165,7 +168,7 @@ Set server_name as default value to notif_from.
 
 ---
 
-<a href="../src/charm_state.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_yes_or_no`
 

--- a/src-docs/charm_types.py.md
+++ b/src-docs/charm_types.py.md
@@ -28,6 +28,22 @@ A named tuple representing a Datasource PostgreSQL.
 
 ---
 
+## <kbd>class</kbd> `RedisConfiguration`
+A named tuple representing Redis configuration. 
+
+
+
+**Attributes:**
+ 
+ - <b>`host`</b>:  The hostname of the Redis server. 
+ - <b>`port`</b>:  The port on the Redis server. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `SAMLConfiguration`
 A named tuple representing a SAML configuration. 
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -57,6 +57,30 @@ Change the configuration.
 
 ---
 
+<a href="../src/pebble.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `enable_redis`
+
+```python
+enable_redis(container: Container) → None
+```
+
+Enable Redis while receiving on_redis_relation_updated event. 
+
+
+
+**Args:**
+ 
+ - <b>`container`</b>:  Charm container. 
+
+
+
+**Raises:**
+ 
+ - <b>`PebbleServiceError`</b>:  if something goes wrong while interacting with Pebble. 
+
+---
+
 <a href="../src/pebble.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `enable_saml`
@@ -141,7 +165,7 @@ Replan Synapse NGINX service.
 
 ---
 
-<a href="../src/pebble.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L171"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reset_instance`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -94,7 +94,7 @@ Change the configuration.
 
 ---
 
-<a href="../src/pebble.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_redis`
 
@@ -120,7 +120,7 @@ Enable Redis while receiving on_redis_relation_updated event.
 
 ---
 
-<a href="../src/pebble.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L135"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_saml`
 
@@ -146,7 +146,7 @@ Enable SAML while receiving on_saml_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L150"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_smtp`
 
@@ -172,7 +172,7 @@ Enable SMTP while receiving on_smtp_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L171"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src-docs/redis_observer.py.md
+++ b/src-docs/redis_observer.py.md
@@ -14,7 +14,7 @@ The Redis relation observer.
 
 Attrs:  on: listen to Redis events.  _stored: stored state. 
 
-<a href="../src/redis_observer.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/redis_observer.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -38,5 +38,22 @@ Initialize the observer and register event handlers.
 Shortcut for more simple access the model. 
 
 
+
+---
+
+<a href="../src/redis_observer.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_relation_as_redis_conf`
+
+```python
+get_relation_as_redis_conf() → Optional[RedisConfiguration]
+```
+
+Get the hostname and port from the redis relation data. 
+
+
+
+**Returns:**
+  RedisConfiguration instance with the hostname and port of the related redis or None  if not found. 
 
 

--- a/src-docs/redis_observer.py.md
+++ b/src-docs/redis_observer.py.md
@@ -12,9 +12,7 @@ The Redis agent relation observer.
 ## <kbd>class</kbd> `RedisObserver`
 The Redis relation observer. 
 
-Attrs:  on: listen to Redis events.  _stored: stored state. 
-
-<a href="../src/redis_observer.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/redis_observer.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -41,7 +39,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/redis_observer.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/redis_observer.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_relation_as_redis_conf`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,6 +57,7 @@ class SynapseCharm(ops.CharmBase):
                 datasource=self._database.get_relation_as_datasource(),
                 saml_config=self._saml.get_relation_as_saml_conf(),
                 smtp_config=self._smtp.get_relation_as_smtp_conf(),
+                redis_config=self._redis.get_relation_as_redis_conf(),
             )
         except CharmConfigInvalidError as exc:
             self.model.unit.status = ops.BlockedStatus(exc.msg)

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,7 @@ import typing
 
 import ops
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
+from charms.redis_k8s.v0.redis import RedisRelationCharmEvents
 from charms.traefik_k8s.v1.ingress import IngressPerAppRequirer
 from ops.charm import ActionEvent
 from ops.main import main
@@ -33,11 +34,16 @@ logger = logging.getLogger(__name__)
 
 
 class SynapseCharm(ops.CharmBase):
-    """Charm the service."""
+    """Charm the service.
+
+    Attrs:
+        on: listen to Redis events.
+    """
 
     # This class has several instance attributes like observers, libraries and state.
     # Consider refactoring if more attributes are added.
     # pylint: disable=too-many-instance-attributes
+    on = RedisRelationCharmEvents()
 
     def __init__(self, *args: typing.Any) -> None:
         """Construct.

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -20,7 +20,12 @@ from pydantic import (  # pylint: disable=no-name-in-module,import-error
     validator,
 )
 
-from charm_types import DatasourcePostgreSQL, SAMLConfiguration, SMTPConfiguration
+from charm_types import (
+    DatasourcePostgreSQL,
+    RedisConfiguration,
+    SAMLConfiguration,
+    SMTPConfiguration,
+)
 
 
 class CharmConfigInvalidError(Exception):
@@ -137,6 +142,7 @@ class CharmState:
         datasource: datasource information.
         saml_config: saml configuration.
         smtp_config: smtp configuration.
+        redis_config: redis configuration.
         proxy: proxy information.
     """
 
@@ -144,6 +150,7 @@ class CharmState:
     datasource: typing.Optional[DatasourcePostgreSQL]
     saml_config: typing.Optional[SAMLConfiguration]
     smtp_config: typing.Optional[SMTPConfiguration]
+    redis_config: typing.Optional[RedisConfiguration]
 
     @property
     def proxy(self) -> "ProxyConfig":
@@ -161,13 +168,15 @@ class CharmState:
             no_proxy=no_proxy,
         )
 
+    # from_charm receives configuration from all integration so too many arguments.
     @classmethod
-    def from_charm(
+    def from_charm(  # pylint: disable=too-many-arguments
         cls,
         charm: ops.CharmBase,
         datasource: typing.Optional[DatasourcePostgreSQL],
         saml_config: typing.Optional[SAMLConfiguration],
         smtp_config: typing.Optional[SMTPConfiguration],
+        redis_config: typing.Optional[RedisConfiguration],
     ) -> "CharmState":
         """Initialize a new instance of the CharmState class from the associated charm.
 
@@ -176,6 +185,7 @@ class CharmState:
             datasource: datasource information to be used by Synapse.
             saml_config: saml configuration to be used by Synapse.
             smtp_config: SMTP configuration to be used by Synapse.
+            redis_config: Redis configuration to be used by Synapse.
 
         Return:
             The CharmState instance created by the provided charm.
@@ -198,4 +208,5 @@ class CharmState:
             datasource=datasource,
             saml_config=saml_config,
             smtp_config=smtp_config,
+            redis_config=redis_config,
         )

--- a/src/charm_types.py
+++ b/src/charm_types.py
@@ -63,3 +63,16 @@ class SMTPConfiguration(typing.TypedDict):
     enable_tls: bool
     force_tls: bool
     require_transport_security: bool
+
+
+@dataclass(frozen=True)
+class RedisConfiguration(typing.TypedDict):
+    """A named tuple representing Redis configuration.
+
+    Attributes:
+        host: The hostname of the Redis server.
+        port: The port on the Redis server.
+    """
+
+    host: str
+    port: int

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -91,6 +91,9 @@ def change_config(charm_state: CharmState, container: ops.model.Container) -> No
         if charm_state.smtp_config is not None:
             logger.debug("pebble.change_config: Enabling SMTP")
             synapse.enable_smtp(container=container, charm_state=charm_state)
+        if charm_state.redis_config is not None:
+            logger.debug("pebble.change_config: Enabling Redis")
+            synapse.enable_redis(container=container, charm_state=charm_state)
         if not charm_state.synapse_config.enable_password_config:
             synapse.disable_password_config(container=container)
         if charm_state.synapse_config.federation_domain_whitelist:

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -152,6 +152,22 @@ class PebbleService:
         except (synapse.WorkloadError, ops.pebble.PathError) as exc:
             raise PebbleServiceError(str(exc)) from exc
 
+    def enable_redis(self, container: ops.model.Container) -> None:
+        """Enable Redis while receiving on_redis_relation_updated event.
+
+        Args:
+            container: Charm container.
+
+        Raises:
+            PebbleServiceError: if something goes wrong while interacting with Pebble.
+        """
+        try:
+            logger.debug("pebble.enable_redis: Enabling Redis")
+            synapse.enable_redis(container=container, charm_state=self._charm_state)
+            self.restart_synapse(container)
+        except (synapse.WorkloadError, ops.pebble.PathError) as exc:
+            raise PebbleServiceError(str(exc)) from exc
+
     def reset_instance(self, container: ops.model.Container) -> None:
         """Reset instance.
 

--- a/src/redis_observer.py
+++ b/src/redis_observer.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, Optional
 
 import ops
-from charms.redis_k8s.v0.redis import RedisRelationCharmEvents, RedisRequires
+from charms.redis_k8s.v0.redis import RedisRequires
 from ops.charm import CharmBase, HookEvent
 from ops.framework import Object, StoredState
 
@@ -19,14 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 class RedisObserver(Object):
-    """The Redis relation observer.
+    """The Redis relation observer."""
 
-    Attrs:
-        on: listen to Redis events.
-        _stored: stored state.
-    """
-
-    on = RedisRelationCharmEvents()
     _stored = StoredState()
 
     def __init__(self, charm: CharmBase):
@@ -40,9 +34,10 @@ class RedisObserver(Object):
         self._stored.set_default(
             redis_relation={},
         )
-        self._stored.set_default(redis_relation={})
         self.redis = RedisRequires(self._charm, self._stored)
-        self.framework.observe(self.on.redis_relation_updated, self._on_redis_relation_updated)
+        self.framework.observe(
+            self._charm.on.redis_relation_updated, self._on_redis_relation_updated
+        )
 
     def get_relation_as_redis_conf(self) -> Optional[RedisConfiguration]:
         """Get the hostname and port from the redis relation data.

--- a/src/redis_observer.py
+++ b/src/redis_observer.py
@@ -4,10 +4,16 @@
 """The Redis agent relation observer."""
 
 import logging
+from typing import Any, Optional
 
+import ops
 from charms.redis_k8s.v0.redis import RedisRelationCharmEvents, RedisRequires
 from ops.charm import CharmBase, HookEvent
 from ops.framework import Object, StoredState
+
+import synapse
+from charm_types import RedisConfiguration
+from pebble import PebbleServiceError
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +44,61 @@ class RedisObserver(Object):
         self.redis = RedisRequires(self._charm, self._stored)
         self.framework.observe(self.on.redis_relation_updated, self._on_redis_relation_updated)
 
+    def get_relation_as_redis_conf(self) -> Optional[RedisConfiguration]:
+        """Get the hostname and port from the redis relation data.
+
+        Returns:
+            RedisConfiguration instance with the hostname and port of the related redis or None
+            if not found.
+        """
+        redis_config = None
+        # This is the current recommended way of accessing the relation data.
+        for redis_unit in self._stored.redis_relation:  # type: ignore
+            # mypy fails to see that this is indexable
+            redis_unit_data = self._stored.redis_relation[redis_unit]  # type: ignore
+            try:
+                redis_hostname = str(redis_unit_data.get("hostname"))
+                redis_port = int(redis_unit_data.get("port"))
+                redis_config = RedisConfiguration(host=redis_hostname, port=redis_port)
+            except (ValueError, TypeError) as exc:
+                # the relation databag is empty at that point.
+                logger.exception("Failed to get Redis relation data: %s", str(exc))
+                return None
+
+            logger.debug(
+                "Got redis connection details from relation of %s:%s", redis_hostname, redis_port
+            )
+        if not redis_config:
+            logger.info("Redis databag is empty.")
+        return redis_config
+
+    def _enable_redis(self) -> None:
+        """Enable Redis."""
+        # Other observers do this check too.
+        container = self._charm.unit.get_container(
+            synapse.SYNAPSE_CONTAINER_NAME
+        )  # pylint: disable=duplicate-code
+        if not container.can_connect() or self._pebble_service is None:
+            self._charm.unit.status = ops.MaintenanceStatus("Waiting for Synapse pebble")
+            return
+        try:
+            self._pebble_service.enable_redis(container)
+        except PebbleServiceError as exc:
+            self._charm.model.unit.status = ops.BlockedStatus(f"Redis integration failed: {exc}")
+            return
+        self._charm.unit.status = ops.ActiveStatus()
+
     def _on_redis_relation_updated(self, _: HookEvent) -> None:
         """Handle redis relation updated event."""
-        logger.info("Redis relation changed.")
+        self.model.unit.status = ops.MaintenanceStatus("Preparing the Redis integration")
+        logger.debug("_on_redis_relation_updated: Enabling Redis")
+        self._enable_redis()
+
+    @property
+    def _pebble_service(self) -> Any:
+        """Return instance of pebble service.
+
+        Returns:
+            instance of pebble service or none.
+        """
+        return getattr(self._charm, "pebble_service", None)

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -66,6 +66,7 @@ from .workload import (  # noqa: F401
     enable_forgotten_room_retention,
     enable_ip_range_whitelist,
     enable_metrics,
+    enable_redis,
     enable_saml,
     enable_serve_server_wellknown,
     enable_smtp,

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -678,6 +678,36 @@ def enable_smtp(container: ops.Container, charm_state: CharmState) -> None:
         raise EnableSMTPError(str(exc)) from exc
 
 
+def enable_redis(container: ops.Container, charm_state: CharmState) -> None:
+    """Change the Synapse configuration to enable Redis.
+
+    Args:
+        container: Container of the charm.
+        charm_state: Instance of CharmState.
+
+    Raises:
+        WorkloadError: something went wrong enabling SMTP.
+    """
+    try:
+        config = container.pull(SYNAPSE_CONFIG_PATH).read()
+        current_yaml = yaml.safe_load(config)
+        current_yaml["redis"] = {}
+
+        if charm_state.redis_config is None:
+            raise WorkloadError(
+                "Redis Configuration not found. "
+                "Please verify the integration between Redis and Synapse."
+            )
+
+        redis_config = charm_state.redis_config
+        current_yaml["redis"]["enabled"] = True
+        current_yaml["redis"]["host"] = redis_config["host"]
+        current_yaml["email"]["port"] = redis_config["port"]
+        container.push(SYNAPSE_CONFIG_PATH, yaml.safe_dump(current_yaml))
+    except ops.pebble.PathError as exc:
+        raise WorkloadError(str(exc)) from exc
+
+
 def reset_instance(container: ops.Container) -> None:
     """Erase data and config server_name.
 

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -702,7 +702,7 @@ def enable_redis(container: ops.Container, charm_state: CharmState) -> None:
         redis_config = charm_state.redis_config
         current_yaml["redis"]["enabled"] = True
         current_yaml["redis"]["host"] = redis_config["host"]
-        current_yaml["email"]["port"] = redis_config["port"]
+        current_yaml["redis"]["port"] = redis_config["port"]
         container.push(SYNAPSE_CONFIG_PATH, yaml.safe_dump(current_yaml))
     except ops.pebble.PathError as exc:
         raise WorkloadError(str(exc)) from exc

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for Synapse charm integrated with Redis."""
+import logging
+import typing
+
+import pytest
+from juju.application import Application
+from juju.model import Model
+from ops.model import ActiveStatus
+
+# caused by pytest fixtures
+# pylint: disable=too-many-arguments
+
+# mypy has trouble to inferred types for variables that are initialized in subclasses.
+ACTIVE_STATUS_NAME = typing.cast(str, ActiveStatus.name)  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.redis
+async def test_synapse_enable_redis(
+    model: Model,
+    synapse_app: Application,
+    relation_name: str,
+):
+    """
+    arrange: build and deploy the Synapse charm.
+    act:  integrate with Redis.
+    assert: the Synapse application is active.
+    """
+    redis_app = await model.deploy(
+        "redis-k8s",
+        channel="latest/edge",
+    )
+    await model.wait_for_idle(status=ACTIVE_STATUS_NAME)
+    await model.add_relation(f"{redis_app.name}:{relation_name}", synapse_app.name)
+    await model.wait_for_idle(
+        idle_period=30,
+        apps=[synapse_app.name, redis_app.name],
+        status=ACTIVE_STATUS_NAME,
+    )

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 async def test_synapse_enable_redis(
     model: Model,
     synapse_app: Application,
-    relation_name: str,
 ):
     """
     arrange: build and deploy the Synapse charm.
@@ -36,7 +35,7 @@ async def test_synapse_enable_redis(
         channel="latest/edge",
     )
     await model.wait_for_idle(status=ACTIVE_STATUS_NAME)
-    await model.add_relation(f"{redis_app.name}:{relation_name}", synapse_app.name)
+    await model.add_relation(f"{redis_app.name}:redis", synapse_app.name)
     await model.wait_for_idle(
         idle_period=30,
         apps=[synapse_app.name, redis_app.name],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -212,6 +212,19 @@ def smtp_configured_fixture(harness: Harness) -> Harness:
     return harness
 
 
+@pytest.fixture(name="redis_configured")
+def redis_configured_fixture(harness: Harness) -> Harness:
+    """Harness fixture with redis relation configured"""
+    harness.update_config({"server_name": TEST_SERVER_NAME, "public_baseurl": TEST_SERVER_NAME})
+    redis_relation_id = harness.add_relation(
+        "redis", "redis", app_data={"hostname": "redis-host", "port": "1010"}
+    )
+    harness.add_relation_unit(redis_relation_id, "redis/0")
+    harness.set_can_connect(synapse.SYNAPSE_CONTAINER_NAME, True)
+    harness.set_leader(True)
+    return harness
+
+
 @pytest.fixture(name="container_mocked")
 def container_mocked_fixture(monkeypatch: pytest.MonkeyPatch) -> unittest.mock.MagicMock:
     """Mock container base to others fixtures."""

--- a/tests/unit/test_admin_access_token.py
+++ b/tests/unit/test_admin_access_token.py
@@ -1,0 +1,86 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Admin Access Token unit tests."""
+
+# pylint: disable=protected-access
+
+from secrets import token_hex
+from unittest.mock import MagicMock, patch
+
+import ops
+import pytest
+from ops.testing import Harness
+
+import synapse
+
+
+@patch("admin_access_token.JUJU_HAS_SECRETS", True)
+@patch.object(ops.Application, "add_secret")
+def test_get_admin_access_token_with_secrets(
+    mock_add_secret, harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    arrange: start the Synapse charm, mock register_user and add_secret.
+    act: get admin access token.
+    assert: admin user is created, secret is created and the token is retrieved.
+    """
+    harness.begin_with_initial_hooks()
+    # Mocking like the following doesn't get evaluated as expected
+    # mock_juju_env.return_value = MagicMock(has_secrets=True)
+    secret_mock = MagicMock
+    secret_id = token_hex(16)
+    secret_mock.id = secret_id
+    mock_add_secret.return_value = secret_mock
+    user_mock = MagicMock()
+    admin_access_token_expected = token_hex(16)
+    user_mock.access_token = admin_access_token_expected
+    create_admin_user_mock = MagicMock(return_value=user_mock)
+    monkeypatch.setattr(synapse, "create_admin_user", create_admin_user_mock)
+
+    admin_access_token = harness.charm.token_service.get(MagicMock)
+
+    create_admin_user_mock.assert_called_once()
+    mock_add_secret.assert_called_once()
+    assert admin_access_token == admin_access_token_expected
+    peer_relation = harness.model.get_relation("synapse-peers")
+    assert peer_relation
+    assert (
+        harness.get_relation_data(peer_relation.id, harness.charm.app.name).get("secret-id")
+        == secret_id
+    )
+    assert isinstance(harness.model.unit.status, ops.ActiveStatus)
+
+
+@patch("admin_access_token.JUJU_HAS_SECRETS", False)
+@patch.object(ops.Application, "add_secret")
+def test_get_admin_access_token_no_secrets(
+    mock_add_secret, harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    arrange: start the Synapse charm, mock register_user and add_secret.
+    act: get admin access token.
+    assert: admin user is created, relation is updated and the token is
+        retrieved.
+    """
+    harness.begin_with_initial_hooks()
+    # Mocking like the following doesn't get evaluated as expected
+    # mock_juju_env.return_value = MagicMock(has_secrets=True)
+    user_mock = MagicMock()
+    admin_access_token_expected = token_hex(16)
+    user_mock.access_token = admin_access_token_expected
+    create_admin_user_mock = MagicMock(return_value=user_mock)
+    monkeypatch.setattr(synapse, "create_admin_user", create_admin_user_mock)
+
+    admin_access_token = harness.charm.token_service.get(MagicMock)
+
+    create_admin_user_mock.assert_called_once()
+    mock_add_secret.assert_not_called()
+    assert admin_access_token == admin_access_token_expected
+    peer_relation = harness.model.get_relation("synapse-peers")
+    assert peer_relation
+    assert (
+        harness.get_relation_data(peer_relation.id, harness.charm.app.name).get("secret-key")
+        == admin_access_token_expected
+    )
+    assert isinstance(harness.model.unit.status, ops.ActiveStatus)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -440,7 +440,7 @@ def test_redis_relation_pebble_success(redis_configured: Harness, monkeypatch: p
     monkeypatch.setattr(synapse, "enable_redis", enable_redis_mock)
     harness.begin()
 
-    harness.charm._redis.on.redis_relation_updated.emit()
+    harness.charm.on.redis_relation_updated.emit()
 
     enable_redis_mock.assert_called_once_with(
         container=container, charm_state=harness.charm._charm_state
@@ -460,7 +460,7 @@ def test_redis_relation_pebble_error(redis_configured: Harness, monkeypatch: pyt
     enable_redis_mock = MagicMock(side_effect=PebbleServiceError("fail"))
     monkeypatch.setattr(harness.charm._redis._pebble_service, "enable_redis", enable_redis_mock)
 
-    harness.charm._redis.on.redis_relation_updated.emit()
+    harness.charm.on.redis_relation_updated.emit()
 
     assert isinstance(harness.model.unit.status, ops.BlockedStatus)
     assert "Redis integration failed" in str(harness.model.unit.status)

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -225,6 +225,7 @@ def test_override_rate_limit_success(monkeypatch: pytest.MonkeyPatch):
         datasource=None,
         saml_config=None,
         smtp_config=None,
+        redis_config=None,
     )
     expected_url = (
         f"http://localhost:8008/_synapse/admin/v1/users/@any-user:{server}/override_ratelimit"
@@ -258,6 +259,7 @@ def test_override_rate_limit_error(monkeypatch: pytest.MonkeyPatch):
         datasource=None,
         saml_config=None,
         smtp_config=None,
+        redis_config=None,
     )
     expected_error_msg = "Failed to connect"
     do_request_mock = mock.MagicMock(side_effect=synapse.APIError(expected_error_msg))

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -262,7 +262,11 @@ def test_enable_ip_range_whitelist_no_action(harness: Harness, monkeypatch: pyte
     synapse.enable_ip_range_whitelist(
         container_mock,
         CharmState(
-            datasource=None, saml_config=None, smtp_config=None, synapse_config=synapse_config
+            datasource=None,
+            saml_config=None,
+            smtp_config=None,
+            redis_config=None,
+            synapse_config=synapse_config,
         ),
     )
 
@@ -361,7 +365,11 @@ listeners:
     synapse.enable_trusted_key_servers(
         container,
         CharmState(
-            datasource=None, saml_config=None, smtp_config=None, synapse_config=synapse_config
+            datasource=None,
+            saml_config=None,
+            smtp_config=None,
+            redis_config=None,
+            synapse_config=synapse_config,
         ),
     )
 
@@ -770,6 +778,7 @@ def test_enable_smtp_success(monkeypatch: pytest.MonkeyPatch):
         datasource=None,
         saml_config=None,
         smtp_config=SMTP_CONFIGURATION,
+        redis_config=None,
         synapse_config=SynapseConfig(
             federation_domain_whitelist=None,
             ip_range_whitelist=None,
@@ -818,6 +827,7 @@ def test_enable_smtp_error(monkeypatch: pytest.MonkeyPatch):
         datasource=None,
         saml_config=None,
         smtp_config=SMTP_CONFIGURATION,
+        redis_config=None,
         synapse_config=SynapseConfig(
             federation_domain_whitelist=None,
             ip_range_whitelist=None,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

After integrating with Redis, the charm will change the Synapse configuration with host and port information from relation data.

### Rationale

Redis integration is required by horizontal scaling configuration.

### Juju Events Changes

redis_relation_updated changes Synapse configuration via pebble_service.

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
