### PR TITLE
Increase memory alert to 3GB

### DIFF
--- a/src/prometheus_alert_rules/synapse.rule
+++ b/src/prometheus_alert_rules/synapse.rule
@@ -37,13 +37,13 @@ groups:
       summary: Synapse High CPU utilization (instance {{ $labels.instance }})
       description: "Synapse CPU utilization is above 90% for 2 minutes.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
   - alert: SynapseHighMemoryUtilization
-    expr: process_resident_memory_bytes{juju_charm="synapse"} / 1024 / 1024 > 1024
+    expr: process_resident_memory_bytes{juju_charm="synapse"} / 1024 / 1024 > 3072
     for: 2m
     labels:
       severity: critical
     annotations:
       summary: Synapse High Memory utilization (instance {{ $labels.instance }})
-      description: "Synapse Memory utilization is above 1GB for 2 minutes.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+      description: "Synapse Memory utilization is above 3GB for 2 minutes.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
   - alert: SynapseTooManyOpenFiles
     expr: process_open_fds{juju_charm="synapse"} > 1024
     for: 2m


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->
Update alert memory to 3GB, as the previous limit, 1GB is insufficient for a federated server where users use big rooms.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
