### PR TITLE
Set stream_writers configuration

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -91,7 +91,7 @@ Build charm state.
 
 ---
 
-<a href="../src/charm.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L166"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 
@@ -109,7 +109,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L292"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L295"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit`
 
@@ -131,7 +131,7 @@ Get main unit.
 ### <kbd>function</kbd> `instance_map`
 
 ```python
-instance_map() → Dict
+instance_map() → Optional[Dict]
 ```
 
 Build instance_map config. 
@@ -139,7 +139,7 @@ Build instance_map config.
 
 
 **Returns:**
-  Instance map configuration as a dict. 
+  Instance map configuration as a dict or None if there is only one unit. 
 
 ---
 
@@ -161,7 +161,7 @@ Verify if this unit is the main.
 
 ---
 
-<a href="../src/charm.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L272"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `peer_units_total`
 
@@ -178,7 +178,7 @@ Get peer units total.
 
 ---
 
-<a href="../src/charm.py#L307"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L310"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `set_main_unit`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -127,7 +127,7 @@ Change the configuration (main and worker).
 
 ---
 
-<a href="../src/pebble.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L165"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_redis`
 
@@ -153,7 +153,7 @@ Enable Redis while receiving on_redis_relation_updated event.
 
 ---
 
-<a href="../src/pebble.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_saml`
 
@@ -179,7 +179,7 @@ Enable SAML while receiving on_saml_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_smtp`
 
@@ -205,7 +205,7 @@ Enable SMTP while receiving on_smtp_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L219"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -124,12 +124,15 @@ class SynapseCharm(CharmBaseWithState):
         """
         return self.get_main_unit() == self.unit.name
 
-    def instance_map(self) -> typing.Dict:
+    def instance_map(self) -> typing.Optional[typing.Dict]:
         """Build instance_map config.
 
         Returns:
-            Instance map configuration as a dict.
+            Instance map configuration as a dict or None if there is only one unit.
         """
+        if self.peer_units_total() == 1:
+            logger.debug("Only 1 unit found, skipping instance_map.")
+            return None
         unit_name = self.unit.name.replace("/", "-")
         app_name = self.app.name
         addresses = [f"{unit_name}.{app_name}-endpoints"]

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -124,7 +124,9 @@ def change_config(  # noqa: C901
         synapse.enable_replication(container=container)
         synapse.enable_forgotten_room_retention(container=container)
         synapse.enable_serve_server_wellknown(container=container)
-        synapse.enable_instance_map(container=container, charm_state=charm_state)
+        if charm_state.instance_map_config:
+            synapse.enable_instance_map(container=container, charm_state=charm_state)
+            synapse.enable_stream_writers(container=container, charm_state=charm_state)
         if charm_state.saml_config is not None:
             logger.debug("pebble.change_config: Enabling SAML")
             synapse.enable_saml(container=container, charm_state=charm_state)

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -75,6 +75,7 @@ from .workload import (  # noqa: F401
     enable_saml,
     enable_serve_server_wellknown,
     enable_smtp,
+    enable_stream_writers,
     enable_trusted_key_servers,
     execute_migrate_config,
     get_environment,

--- a/tests/unit/test_charm_scaling.py
+++ b/tests/unit/test_charm_scaling.py
@@ -171,3 +171,33 @@ def test_scaling_instance_map_configured(harness: Harness) -> None:
                 "port": 8034,
             },
         }
+
+
+def test_scaling_stream_writers_configured(harness: Harness) -> None:
+    """
+    arrange: charm deployed, integrated with Redis and set as leader.
+    act: scale charm to more than 1 unit.
+    assert: Synapse charm is configured with stream_writer.
+    """
+    rel_id = harness.add_relation(synapse.SYNAPSE_PEER_RELATION_NAME, "synapse")
+    harness.add_relation_unit(rel_id, "synapse/1")
+    harness.add_relation_unit(rel_id, "synapse/2")
+    harness.begin_with_initial_hooks()
+    relation = harness.charm.framework.model.get_relation("redis", 0)
+    # We need to bypass protected access to inject the relation data
+    # pylint: disable=protected-access
+    harness.charm._redis._stored.redis_relation = {
+        relation.id: ({"hostname": "redis-host", "port": 1010})
+    }
+    harness.set_leader(True)
+
+    harness.charm.on.config_changed.emit()
+
+    root = harness.get_filesystem_root(synapse.SYNAPSE_CONTAINER_NAME)
+    config_path = root / synapse.SYNAPSE_CONFIG_PATH[1:]
+    with open(config_path, encoding="utf-8") as config_file:
+        content = yaml.safe_load(config_file)
+        assert "stream_writers" in content
+        expected_events = ["worker1", "worker2"]
+        actual_events = content["stream_writers"]["events"]
+        assert sorted(actual_events) == sorted(expected_events)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Stream writers configuration allow move specific streams (such as events) off of the main process to a particular worker. This is required by horizontal scaling architecture.

### Rationale

The [stream_writers](https://matrix-org.github.io/synapse/latest/workers.html#stream-writers) configuration defined.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Charmhub doc will be updated when horizontal scaling is completely in place.