### PR TITLE
fix(irc): Use default ircs port

### DIFF
--- a/templates/irc_bridge_production.yaml
+++ b/templates/irc_bridge_production.yaml
@@ -8,7 +8,7 @@ ircService:
       name: "LiberaChat"
       onlyAdditionalAddresses: false
       networkId: "libera"
-      port: 7000
+      port: 6697
       ssl: true
       sslselfsign: true
       sasl: true


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

### Rationale

Changes the port from non standard 7000 to the ircs port 6697. This is also the port allowed on the firewall.

<!-- The reason the change is needed -->

### Juju Events Changes

n/a
<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

n/a
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

n/a
<!-- Any changes to charm libraries -->

### Checklist

- [ x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ x] The documentation is generated using `src-docs`
- [ x] The documentation for charmhub is updated.
- [ x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
