### PR TITLE
Restart worker for relation departed and relation changed

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -109,7 +109,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L318"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L320"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit`
 
@@ -126,7 +126,7 @@ Get main unit.
 
 ---
 
-<a href="../src/charm.py#L333"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit_address`
 
@@ -202,7 +202,7 @@ Verify if this unit is the main.
 
 ---
 
-<a href="../src/charm.py#L295"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L297"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `peer_units_total`
 
@@ -219,7 +219,7 @@ Get peer units total.
 
 ---
 
-<a href="../src/charm.py#L345"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L347"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `set_main_unit`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -290,7 +290,9 @@ class SynapseCharm(CharmBaseWithState):
         ):
             # Main is gone so I'm the leader and will be the new main
             self.set_main_unit(self.unit.name)
-            self.change_config(charm_state)
+        # Call change_config to restart unit. By design,every change in the
+        # number of workers requires restart.
+        self.change_config(charm_state)
 
     def peer_units_total(self) -> int:
         """Get peer units total.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

Note: Integration test will be added in further story/PR.

### Overview

Synapse Horizontal scaling design requires that for every change in the number of worker (up or down), they all should be restarted. This PR does that by observing events relation-changed and relation-departed, for each of them, if the unit is not the main unit  then will be restarted.

### Rationale

Restart workers as required by horizontal scaling design.

### Juju Events Changes

Relation departed event.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Documentation will be added in horizontal scaling is in place.