### PR TITLE
Move check for what unit is main to CharmState

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -91,7 +91,7 @@ Build charm state.
 
 ---
 
-<a href="../src/charm.py#L188"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 
@@ -109,7 +109,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L321"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L320"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit`
 
@@ -126,7 +126,7 @@ Get main unit.
 
 ---
 
-<a href="../src/charm.py#L336"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit_address`
 
@@ -143,7 +143,7 @@ Get main unit address. If main unit is None, use unit name.
 
 ---
 
-<a href="../src/charm.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_unit_number`
 
@@ -167,7 +167,7 @@ Get unit number from unit name.
 
 ---
 
-<a href="../src/charm.py#L152"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `instance_map`
 
@@ -184,7 +184,7 @@ Build instance_map config.
 
 ---
 
-<a href="../src/charm.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_main`
 
@@ -202,7 +202,7 @@ Verify if this unit is the main.
 
 ---
 
-<a href="../src/charm.py#L298"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L297"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `peer_units_total`
 
@@ -219,7 +219,7 @@ Get peer units total.
 
 ---
 
-<a href="../src/charm.py#L348"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L347"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `set_main_unit`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -74,7 +74,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L161"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_charm_state`
 
@@ -91,7 +91,7 @@ Build charm state.
 
 ---
 
-<a href="../src/charm.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L246"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 
@@ -109,7 +109,7 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L320"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit`
 
@@ -126,7 +126,7 @@ Get main unit.
 
 ---
 
-<a href="../src/charm.py#L335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit_address`
 
@@ -143,7 +143,7 @@ Get main unit address. If main unit is None, use unit name.
 
 ---
 
-<a href="../src/charm.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_unit_number`
 
@@ -167,7 +167,7 @@ Get unit number from unit name.
 
 ---
 
-<a href="../src/charm.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L210"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `instance_map`
 
@@ -184,7 +184,7 @@ Build instance_map config.
 
 ---
 
-<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_main`
 
@@ -202,7 +202,7 @@ Verify if this unit is the main.
 
 ---
 
-<a href="../src/charm.py#L297"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L350"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `peer_units_total`
 
@@ -216,23 +216,5 @@ Get peer units total.
 
 **Returns:**
   total of units in peer relation or None if there is no peer relation. 
-
----
-
-<a href="../src/charm.py#L347"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `set_main_unit`
-
-```python
-set_main_unit(unit: str) → None
-```
-
-Create/Renew an admin access token and put it in the peer relation. 
-
-
-
-**Args:**
- 
- - <b>`unit`</b>:  Unit to be the main. 
 
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -157,6 +157,7 @@ State of the Charm.
  - <b>`redis_config`</b>:  redis configuration. 
  - <b>`proxy`</b>:  proxy information. 
  - <b>`instance_map_config`</b>:  Instance map configuration with main and worker addresses. 
+ - <b>`main_unit`</b>:  If is the main unit or not. 
 
 
 ---
@@ -174,7 +175,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L306"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -187,7 +188,8 @@ from_charm(
     smtp_config: Optional[SMTPConfiguration],
     media_config: Optional[MediaConfiguration],
     redis_config: Optional[RedisConfiguration],
-    instance_map_config: Optional[Dict]
+    instance_map_config: Optional[Dict],
+    main_unit: bool
 ) → CharmState
 ```
 
@@ -205,6 +207,7 @@ Initialize a new instance of the CharmState class from the associated charm.
  - <b>`media_config`</b>:  Media configuration to be used by Synapse. 
  - <b>`redis_config`</b>:  Redis configuration to be used by Synapse. 
  - <b>`instance_map_config`</b>:  Instance map configuration with main and worker addresses. 
+ - <b>`main_unit`</b>:  If is the main unit or not. 
 
 Return: The CharmState instance created by the provided charm. 
 

--- a/src-docs/database_client.py.md
+++ b/src-docs/database_client.py.md
@@ -43,7 +43,7 @@ Initialize a new instance of the Synapse class.
 
 ---
 
-<a href="../src/database_client.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/database_client.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `erase`
 

--- a/src-docs/database_observer.py.md
+++ b/src-docs/database_observer.py.md
@@ -57,7 +57,7 @@ Return the current charm.
 
 ---
 
-<a href="../src/database_observer.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/database_observer.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_relation_as_datasource`
 

--- a/src-docs/database_observer.py.md
+++ b/src-docs/database_observer.py.md
@@ -57,7 +57,7 @@ Return the current charm.
 
 ---
 
-<a href="../src/database_observer.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/database_observer.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_relation_as_datasource`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -261,7 +261,7 @@ Change the configuration (main and worker).
 
 ---
 
-<a href="../src/pebble.py#L351"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L355"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_redis`
 
@@ -287,7 +287,7 @@ Enable Redis while receiving on_redis_relation_updated event.
 
 ---
 
-<a href="../src/pebble.py#L371"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L375"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_saml`
 
@@ -313,7 +313,7 @@ Enable SAML while receiving on_saml_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L391"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L395"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_smtp`
 
@@ -339,7 +339,7 @@ Enable SMTP while receiving on_smtp_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L411"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L415"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_media`
 
@@ -365,7 +365,7 @@ Enable S3 Media while receiving on_media_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L431"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L435"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -54,11 +54,7 @@ Return the Synapse container alive check.
 ## <kbd>function</kbd> `restart_synapse`
 
 ```python
-restart_synapse(
-    charm_state: CharmState,
-    container: Container,
-    is_main: bool = True
-) → None
+restart_synapse(charm_state: CharmState, container: Container) → None
 ```
 
 Restart Synapse service. 
@@ -71,12 +67,11 @@ This will force a restart even if its plan hasn't changed.
  
  - <b>`charm_state`</b>:  Instance of CharmState 
  - <b>`container`</b>:  Synapse container. 
- - <b>`is_main`</b>:  if unit is main. 
 
 
 ---
 
-<a href="../src/pebble.py#L89"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L88"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `check_nginx_ready`
 
@@ -95,7 +90,7 @@ Return the Synapse NGINX container check.
 
 ---
 
-<a href="../src/pebble.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `check_mjolnir_ready`
 
@@ -114,7 +109,7 @@ Return the Synapse Mjolnir service check.
 
 ---
 
-<a href="../src/pebble.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `check_irc_bridge_ready`
 
@@ -133,7 +128,7 @@ Return the Synapse IRC bridge service check.
 
 ---
 
-<a href="../src/pebble.py#L128"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_nginx`
 
@@ -153,7 +148,7 @@ Replan Synapse NGINX service and regenerate configuration.
 
 ---
 
-<a href="../src/pebble.py#L140"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_mjolnir`
 
@@ -172,7 +167,7 @@ Replan Synapse Mjolnir service.
 
 ---
 
-<a href="../src/pebble.py#L150"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L149"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_irc_bridge`
 
@@ -191,7 +186,7 @@ Replan Synapse IRC bridge service.
 
 ---
 
-<a href="../src/pebble.py#L160"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_stats_exporter`
 
@@ -211,7 +206,7 @@ Replan Synapse StatsExporter service.
 
 ---
 
-<a href="../src/pebble.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_worker_config`
 
@@ -235,7 +230,7 @@ Get worker configuration.
 
 ---
 
-<a href="../src/pebble.py#L261"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L260"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_config`
 
@@ -243,7 +238,6 @@ Get worker configuration.
 change_config(
     charm_state: CharmState,
     container: Container,
-    is_main: bool = True,
     unit_number: str = ''
 ) → None
 ```
@@ -256,7 +250,6 @@ Change the configuration (main and worker).
  
  - <b>`charm_state`</b>:  Instance of CharmState 
  - <b>`container`</b>:  Charm container. 
- - <b>`is_main`</b>:  if unit is main. 
  - <b>`unit_number`</b>:  unit number id to set the worker name. 
 
 
@@ -268,7 +261,7 @@ Change the configuration (main and worker).
 
 ---
 
-<a href="../src/pebble.py#L354"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L351"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_redis`
 
@@ -294,7 +287,7 @@ Enable Redis while receiving on_redis_relation_updated event.
 
 ---
 
-<a href="../src/pebble.py#L374"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L371"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_saml`
 
@@ -320,7 +313,7 @@ Enable SAML while receiving on_saml_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L394"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L391"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_smtp`
 
@@ -346,7 +339,7 @@ Enable SMTP while receiving on_smtp_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L414"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L411"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_media`
 
@@ -372,7 +365,7 @@ Enable S3 Media while receiving on_media_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L434"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L431"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -119,6 +119,7 @@ class SynapseCharm(CharmBaseWithState):
             media_config=self._media.get_relation_as_media_conf(),
             redis_config=self._redis.get_relation_as_redis_conf(),
             instance_map_config=self.instance_map(),
+            main_unit=self.is_main(),
         )
 
     def is_main(self) -> bool:
@@ -200,9 +201,7 @@ class SynapseCharm(CharmBaseWithState):
             return
         self.model.unit.status = ops.MaintenanceStatus("Configuring Synapse")
         try:
-            pebble.change_config(
-                charm_state, container, is_main=self.is_main(), unit_number=self.get_unit_number()
-            )
+            pebble.change_config(charm_state, container, unit_number=self.get_unit_number())
         except pebble.PebbleServiceError as exc:
             self.model.unit.status = ops.BlockedStatus(str(exc))
             return
@@ -436,7 +435,7 @@ class SynapseCharm(CharmBaseWithState):
                 container=container, charm_state=charm_state, datasource=datasource
             )
             logger.info("Start Synapse")
-            pebble.restart_synapse(charm_state, container, self.is_main())
+            pebble.restart_synapse(charm_state, container)
             results["reset-instance"] = True
         except (pebble.PebbleServiceError, actions.ResetInstanceError) as exc:
             self.model.unit.status = ops.BlockedStatus(str(exc))

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -269,6 +269,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         redis_config: redis configuration.
         proxy: proxy information.
         instance_map_config: Instance map configuration with main and worker addresses.
+        main_unit: If is the main unit or not.
     """
 
     synapse_config: SynapseConfig
@@ -279,6 +280,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
     media_config: typing.Optional[MediaConfiguration]
     redis_config: typing.Optional[RedisConfiguration]
     instance_map_config: typing.Optional[typing.Dict]
+    main_unit: bool
 
     @property
     def proxy(self) -> "ProxyConfig":
@@ -312,6 +314,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         media_config: typing.Optional[MediaConfiguration],
         redis_config: typing.Optional[RedisConfiguration],
         instance_map_config: typing.Optional[typing.Dict],
+        main_unit: bool,
     ) -> "CharmState":
         """Initialize a new instance of the CharmState class from the associated charm.
 
@@ -324,6 +327,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             media_config: Media configuration to be used by Synapse.
             redis_config: Redis configuration to be used by Synapse.
             instance_map_config: Instance map configuration with main and worker addresses.
+            main_unit: If is the main unit or not.
 
         Return:
             The CharmState instance created by the provided charm.
@@ -350,4 +354,5 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             media_config=media_config,
             redis_config=redis_config,
             instance_map_config=instance_map_config,
+            main_unit=main_unit,
         )

--- a/src/database_client.py
+++ b/src/database_client.py
@@ -86,8 +86,10 @@ class DatabaseClient:
                 )
                 result = curs.fetchone()
                 if result and result != ("C", "C"):
-                    logging.info(
-                        "Database %s has collation as %s, updating", self._database_name, result
+                    logging.debug(
+                        "Prepare database. database_name: %s collation: %s",
+                        self._database_name,
+                        result,
                     )
                     curs.execute(
                         sql.SQL(
@@ -95,9 +97,13 @@ class DatabaseClient:
                             "WHERE datname = {}"
                         ).format(sql.Literal(self._database_name))
                     )
-                logging.info(
-                    "Database %s has collation as %s, skipping", self._database_name, result
-                )
+                    logging.info("Database %s is ready to be used.", self._database_name)
+                else:
+                    logging.info(
+                        "Database %s already has collation as %s, no action.",
+                        self._database_name,
+                        result,
+                    )
         except psycopg2.Error as exc:
             logger.exception("Failed to prepare database: %r", exc)
             raise

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -64,9 +64,7 @@ class DatabaseObserver(Object):
             return
         try:
             # getting information from charm if is main unit or not.
-            pebble.change_config(
-                charm_state, container, is_main=self._charm.is_main()  # type: ignore[attr-defined]
-            )
+            pebble.change_config(charm_state, container)  # type: ignore[attr-defined]
         # Avoiding duplication of code with _change_config in charm.py
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self._charm.model.unit.status = ops.BlockedStatus(f"Database failed: {exc}")

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -86,6 +86,7 @@ class DatabaseObserver(Object):
         db_client = DatabaseClient(datasource=datasource)
         if self.database.relation_name == synapse.SYNAPSE_DB_RELATION_NAME:
             db_client.prepare()
+        self.model.unit.status = ops.MaintenanceStatus("Database is ready")
         self._change_config(charm_state)
 
     @inject_charm_state

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -64,9 +64,7 @@ def check_synapse_alive() -> ops.pebble.CheckDict:
     return check.to_dict()
 
 
-def restart_synapse(
-    charm_state: CharmState, container: ops.model.Container, is_main: bool = True
-) -> None:
+def restart_synapse(charm_state: CharmState, container: ops.model.Container) -> None:
     """Restart Synapse service.
 
     This will force a restart even if its plan hasn't changed.
@@ -74,11 +72,12 @@ def restart_synapse(
     Args:
         charm_state: Instance of CharmState
         container: Synapse container.
-        is_main: if unit is main.
     """
-    logger.debug("Restarting the Synapse container. Main: %s", str(is_main))
+    logger.debug("Restarting the Synapse container. Main: %s", str(charm_state.main_unit))
     container.add_layer(
-        synapse.SYNAPSE_SERVICE_NAME, _pebble_layer(charm_state, is_main), combine=True
+        synapse.SYNAPSE_SERVICE_NAME,
+        _pebble_layer(charm_state),
+        combine=True,
     )
     container.add_layer(
         synapse.SYNAPSE_CRON_SERVICE_NAME, _cron_pebble_layer(charm_state), combine=True
@@ -261,7 +260,6 @@ def get_worker_config(unit_number: str) -> dict:
 def change_config(  # noqa: C901 pylint: disable=too-many-branches,too-many-statements
     charm_state: CharmState,
     container: ops.model.Container,
-    is_main: bool = True,
     unit_number: str = "",
 ) -> None:
     """Change the configuration (main and worker).
@@ -269,7 +267,6 @@ def change_config(  # noqa: C901 pylint: disable=too-many-branches,too-many-stat
     Args:
         charm_state: Instance of CharmState
         container: Charm container.
-        is_main: if unit is main.
         unit_number: unit number id to set the worker name.
 
     Raises:
@@ -344,7 +341,7 @@ def change_config(  # noqa: C901 pylint: disable=too-many-branches,too-many-stat
             # Push main configuration
             _push_synapse_config(container, current_synapse_config)
             synapse.validate_config(container=container)
-            restart_synapse(container=container, charm_state=charm_state, is_main=is_main)
+            restart_synapse(container=container, charm_state=charm_state)
         else:
             logging.info("Configuration has not changed, no action.")
     except (synapse.WorkloadError, ops.pebble.PathError) as exc:
@@ -459,18 +456,17 @@ def reset_instance(charm_state: CharmState, container: ops.model.Container) -> N
         raise PebbleServiceError(str(exc)) from exc
 
 
-def _pebble_layer(charm_state: CharmState, is_main: bool = True) -> ops.pebble.LayerDict:
+def _pebble_layer(charm_state: CharmState) -> ops.pebble.LayerDict:
     """Return a dictionary representing a Pebble layer.
 
     Args:
         charm_state: Instance of CharmState
-        is_main: if unit is main.
 
     Returns:
         pebble layer for Synapse
     """
     command = synapse.SYNAPSE_COMMAND_PATH
-    if not is_main:
+    if not charm_state.main_unit:
         command = (
             f"{command} run -m synapse.app.generic_worker "
             f"--config-path {synapse.SYNAPSE_CONFIG_PATH} "

--- a/src/redis_observer.py
+++ b/src/redis_observer.py
@@ -73,7 +73,7 @@ class RedisObserver(Object):
                 "Got redis connection details from relation of %s:%s", redis_hostname, redis_port
             )
         if not redis_config:
-            logger.info("Redis databag is empty.")
+            logger.info("Redis databag is empty. No action.")
         return redis_config
 
     def _enable_redis(self, charm_state: CharmState) -> None:

--- a/tests/unit/test_charm_scaling.py
+++ b/tests/unit/test_charm_scaling.py
@@ -80,7 +80,12 @@ def test_scaling_main_configured(harness: Harness) -> None:
     act: create peer relation.
     assert: Synapse charm is configured as main.
     """
-    harness.begin_with_initial_hooks()
+    harness.begin()
+    harness.add_relation(
+        synapse.SYNAPSE_PEER_RELATION_NAME,
+        harness.charm.app.name,
+        app_data={"main_unit_id": "synapse/0"},
+    )
     relation = harness.charm.framework.model.get_relation("redis", 0)
     # We need to bypass protected access to inject the relation data
     # pylint: disable=protected-access
@@ -89,7 +94,7 @@ def test_scaling_main_configured(harness: Harness) -> None:
     }
     harness.set_leader(True)
 
-    harness.add_relation(synapse.SYNAPSE_PEER_RELATION_NAME, harness.charm.app.name)
+    harness.charm.on.config_changed.emit()
 
     synapse_layer = harness.get_container_pebble_plan(synapse.SYNAPSE_CONTAINER_NAME).to_dict()[
         "services"

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -38,6 +38,7 @@ class SimpleCharm(CharmBaseWithState):
             media_config=None,
             redis_config=None,
             instance_map_config=None,
+            main_unit=True,
         )
 
 

--- a/tests/unit/test_irc_bridge.py
+++ b/tests/unit/test_irc_bridge.py
@@ -52,6 +52,7 @@ def charm_state_fixture():
             redis_config=None,
             media_config=None,
             instance_map_config=None,
+            main_unit=True,
         )
 
     return charm_state_with_db

--- a/tests/unit/test_media_observer.py
+++ b/tests/unit/test_media_observer.py
@@ -170,6 +170,7 @@ def test_enable_media(harness: Harness, relation_data, expected_status, can_conn
         media_config=harness.charm._media.get_relation_as_media_conf(),
         redis_config=None,
         instance_map_config=None,
+        main_unit=True,
     )
 
     harness.charm._media._enable_media(charm_state)

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -230,6 +230,7 @@ def test_override_rate_limit_success(monkeypatch: pytest.MonkeyPatch):
         media_config=None,
         redis_config=None,
         instance_map_config=None,
+        main_unit=True,
     )
     expected_url = (
         f"http://localhost:8008/_synapse/admin/v1/users/@any-user:{server}/override_ratelimit"
@@ -267,6 +268,7 @@ def test_override_rate_limit_error(monkeypatch: pytest.MonkeyPatch):
         media_config=None,
         redis_config=None,
         instance_map_config=None,
+        main_unit=True,
     )
     expected_error_msg = "Failed to connect"
     do_request_mock = mock.MagicMock(side_effect=synapse.APIError(expected_error_msg))

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -255,6 +255,7 @@ def test_enable_trusted_key_servers_no_action(config_content: dict[str, typing.A
             redis_config=None,
             synapse_config=synapse_config,
             instance_map_config=None,
+            main_unit=True,
         ),
     )
 
@@ -541,6 +542,7 @@ def test_enable_smtp_success(config_content: dict[str, typing.Any]):
         redis_config=None,
         instance_map_config=None,
         synapse_config=synapse_config,
+        main_unit=True,
     )
 
     synapse.enable_smtp(config_content, charm_state)
@@ -718,6 +720,7 @@ def test_publish_rooms_allowlist_success(config_content: dict[str, typing.Any]):
         synapse_config=synapse_config,
         media_config=None,
         instance_map_config=None,
+        main_unit=True,
     )
 
     synapse.enable_room_list_publication_rules(config_content, charm_state)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

During tests with PostgreSQL Machine Charm + Synapse I noticed that sometimes Synapse was started as generic_worker and sometimes as homeserver.

So, I started looking for all references for restart_synapse and found many related to integrations.

Since observers don't have a charm instance for getting relation data, I changed CharmState to receive the value already checked by the charm.


### Rationale

Restart Synapse properly.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->

No CH doc changed.
