### PR TITLE
Test Only - DNM - WIP - Back to square one: trying Leadership event

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -91,7 +91,7 @@ Build charm state.
 
 ---
 
-<a href="../src/charm.py#L188"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L249"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `change_config`
 
@@ -109,12 +109,12 @@ Change configuration.
 
 ---
 
-<a href="../src/charm.py#L321"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L153"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit`
 
 ```python
-get_main_unit() → Optional[str]
+get_main_unit() → str
 ```
 
 Get main unit. 
@@ -126,7 +126,7 @@ Get main unit.
 
 ---
 
-<a href="../src/charm.py#L336"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_main_unit_address`
 
@@ -143,7 +143,25 @@ Get main unit address. If main unit is None, use unit name.
 
 ---
 
-<a href="../src/charm.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_peer_unit_addresses`
+
+```python
+get_peer_unit_addresses() → list[str]
+```
+
+Get peer unit addresses. 
+
+
+
+**Returns:**
+ 
+ - <b>`set`</b>:  Addresses like  <unit-name>.<app-name>-endpoints.<model-name>.svc.cluster.local 
+
+---
+
+<a href="../src/charm.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_unit_number`
 
@@ -167,7 +185,7 @@ Get unit number from unit name.
 
 ---
 
-<a href="../src/charm.py#L152"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L196"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `instance_map`
 
@@ -184,25 +202,7 @@ Build instance_map config.
 
 ---
 
-<a href="../src/charm.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `is_main`
-
-```python
-is_main() → bool
-```
-
-Verify if this unit is the main. 
-
-
-
-**Returns:**
- 
- - <b>`bool`</b>:  true if is the main unit. 
-
----
-
-<a href="../src/charm.py#L298"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `peer_units_total`
 
@@ -216,23 +216,5 @@ Get peer units total.
 
 **Returns:**
   total of units in peer relation or None if there is no peer relation. 
-
----
-
-<a href="../src/charm.py#L348"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `set_main_unit`
-
-```python
-set_main_unit(unit: str) → None
-```
-
-Create/Renew an admin access token and put it in the peer relation. 
-
-
-
-**Args:**
- 
- - <b>`unit`</b>:  Unit to be the main. 
 
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -157,6 +157,7 @@ State of the Charm.
  - <b>`redis_config`</b>:  redis configuration. 
  - <b>`proxy`</b>:  proxy information. 
  - <b>`instance_map_config`</b>:  Instance map configuration with main and worker addresses. 
+ - <b>`leader`</b>:  Is leader. 
 
 
 ---
@@ -174,7 +175,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L306"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -187,7 +188,8 @@ from_charm(
     smtp_config: Optional[SMTPConfiguration],
     media_config: Optional[MediaConfiguration],
     redis_config: Optional[RedisConfiguration],
-    instance_map_config: Optional[Dict]
+    instance_map_config: Optional[Dict],
+    leader: bool
 ) → CharmState
 ```
 
@@ -205,6 +207,7 @@ Initialize a new instance of the CharmState class from the associated charm.
  - <b>`media_config`</b>:  Media configuration to be used by Synapse. 
  - <b>`redis_config`</b>:  Redis configuration to be used by Synapse. 
  - <b>`instance_map_config`</b>:  Instance map configuration with main and worker addresses. 
+ - <b>`leader`</b>:  is leader. 
 
 Return: The CharmState instance created by the provided charm. 
 

--- a/src-docs/database_observer.py.md
+++ b/src-docs/database_observer.py.md
@@ -57,7 +57,7 @@ Return the current charm.
 
 ---
 
-<a href="../src/database_observer.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/database_observer.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_relation_as_datasource`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -54,11 +54,7 @@ Return the Synapse container alive check.
 ## <kbd>function</kbd> `restart_synapse`
 
 ```python
-restart_synapse(
-    charm_state: CharmState,
-    container: Container,
-    is_main: bool = True
-) → None
+restart_synapse(charm_state: CharmState, container: Container) → None
 ```
 
 Restart Synapse service. 
@@ -71,12 +67,11 @@ This will force a restart even if its plan hasn't changed.
  
  - <b>`charm_state`</b>:  Instance of CharmState 
  - <b>`container`</b>:  Synapse container. 
- - <b>`is_main`</b>:  if unit is main. 
 
 
 ---
 
-<a href="../src/pebble.py#L89"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L83"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `check_nginx_ready`
 
@@ -95,7 +90,7 @@ Return the Synapse NGINX container check.
 
 ---
 
-<a href="../src/pebble.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `check_mjolnir_ready`
 
@@ -114,7 +109,7 @@ Return the Synapse Mjolnir service check.
 
 ---
 
-<a href="../src/pebble.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `check_irc_bridge_ready`
 
@@ -133,7 +128,7 @@ Return the Synapse IRC bridge service check.
 
 ---
 
-<a href="../src/pebble.py#L128"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_nginx`
 
@@ -153,7 +148,7 @@ Replan Synapse NGINX service and regenerate configuration.
 
 ---
 
-<a href="../src/pebble.py#L140"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L134"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_mjolnir`
 
@@ -172,7 +167,7 @@ Replan Synapse Mjolnir service.
 
 ---
 
-<a href="../src/pebble.py#L150"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_irc_bridge`
 
@@ -191,7 +186,7 @@ Replan Synapse IRC bridge service.
 
 ---
 
-<a href="../src/pebble.py#L160"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `replan_stats_exporter`
 
@@ -211,7 +206,7 @@ Replan Synapse StatsExporter service.
 
 ---
 
-<a href="../src/pebble.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_worker_config`
 
@@ -235,7 +230,7 @@ Get worker configuration.
 
 ---
 
-<a href="../src/pebble.py#L261"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L255"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_config`
 
@@ -243,7 +238,6 @@ Get worker configuration.
 change_config(
     charm_state: CharmState,
     container: Container,
-    is_main: bool = True,
     unit_number: str = ''
 ) → None
 ```
@@ -256,7 +250,6 @@ Change the configuration (main and worker).
  
  - <b>`charm_state`</b>:  Instance of CharmState 
  - <b>`container`</b>:  Charm container. 
- - <b>`is_main`</b>:  if unit is main. 
  - <b>`unit_number`</b>:  unit number id to set the worker name. 
 
 
@@ -268,7 +261,7 @@ Change the configuration (main and worker).
 
 ---
 
-<a href="../src/pebble.py#L354"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L346"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_redis`
 
@@ -294,7 +287,7 @@ Enable Redis while receiving on_redis_relation_updated event.
 
 ---
 
-<a href="../src/pebble.py#L374"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L366"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_saml`
 
@@ -320,7 +313,7 @@ Enable SAML while receiving on_saml_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L394"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L386"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_smtp`
 
@@ -346,7 +339,7 @@ Enable SMTP while receiving on_smtp_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L414"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L406"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `enable_media`
 
@@ -372,7 +365,7 @@ Enable S3 Media while receiving on_media_data_available event.
 
 ---
 
-<a href="../src/pebble.py#L434"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L426"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -269,6 +269,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         redis_config: redis configuration.
         proxy: proxy information.
         instance_map_config: Instance map configuration with main and worker addresses.
+        leader: Is leader.
     """
 
     synapse_config: SynapseConfig
@@ -279,6 +280,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
     media_config: typing.Optional[MediaConfiguration]
     redis_config: typing.Optional[RedisConfiguration]
     instance_map_config: typing.Optional[typing.Dict]
+    leader: bool
 
     @property
     def proxy(self) -> "ProxyConfig":
@@ -312,6 +314,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         media_config: typing.Optional[MediaConfiguration],
         redis_config: typing.Optional[RedisConfiguration],
         instance_map_config: typing.Optional[typing.Dict],
+        leader: bool,
     ) -> "CharmState":
         """Initialize a new instance of the CharmState class from the associated charm.
 
@@ -324,6 +327,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             media_config: Media configuration to be used by Synapse.
             redis_config: Redis configuration to be used by Synapse.
             instance_map_config: Instance map configuration with main and worker addresses.
+            leader: is leader.
 
         Return:
             The CharmState instance created by the provided charm.
@@ -350,4 +354,5 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             media_config=media_config,
             redis_config=redis_config,
             instance_map_config=instance_map_config,
+            leader=leader,
         )

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -64,9 +64,7 @@ class DatabaseObserver(Object):
             return
         try:
             # getting information from charm if is main unit or not.
-            pebble.change_config(
-                charm_state, container, is_main=self._charm.is_main()  # type: ignore[attr-defined]
-            )
+            pebble.change_config(charm_state, container)  # type: ignore[attr-defined]
         # Avoiding duplication of code with _change_config in charm.py
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self._charm.model.unit.status = ops.BlockedStatus(f"Database failed: {exc}")

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -71,7 +71,7 @@ class SMTPObserver(Object):
             return None
         try:
             relation_data: Optional[SmtpRelationData] = self.smtp.get_relation_data()
-        except ValidationError:
+        except (ValidationError, ValueError):
             # ValidationError happens in the smtp(_legacy)relation_created event, as
             # the relation databag is empty at that point.
             logger.info("SMTP databag is empty. SMTP information will be set in the next event.")

--- a/tests/unit/test_charm_scaling.py
+++ b/tests/unit/test_charm_scaling.py
@@ -4,14 +4,11 @@
 """Synapse charm scaling unit tests."""
 
 import unittest
-from unittest.mock import MagicMock
 
 import ops
-import pytest
 import yaml
 from ops.testing import Harness
 
-import pebble
 import synapse
 
 
@@ -232,43 +229,6 @@ def test_scaling_stream_writers_configured(harness: Harness) -> None:
         assert sorted(actual_events) == sorted(expected_events)
 
 
-def test_scaling_main_unit_changed_nginx_reconfigured(
-    harness: Harness, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """
-    arrange: charm deployed, integrated with Redis, no leader, replan_nginx is mocked.
-    act: update relation data to change the main_unit_id.
-    assert: Synapse NGINX is replanned with the new main unit.
-    """
-    peer_relation_id = harness.add_relation(
-        synapse.SYNAPSE_PEER_RELATION_NAME,
-        "synapse",
-        app_data={"main_unit_id": "synapse/0"},
-    )
-    harness.begin_with_initial_hooks()
-    nginx_container = harness.model.unit.containers[synapse.SYNAPSE_NGINX_CONTAINER_NAME]
-    harness.set_can_connect(nginx_container, True)
-    redis_relation = harness.charm.framework.model.get_relation("redis", 0)
-    # We need to bypass protected access to inject the relation data
-    # pylint: disable=protected-access
-    harness.charm._redis._stored.redis_relation = {
-        redis_relation.id: ({"hostname": "redis-host", "port": 1010})
-    }
-    harness.set_leader(False)
-    # emit nginx ready
-    # assert was called with synapse/0
-    replan_nginx_mock = MagicMock()
-    monkeypatch.setattr(pebble, "replan_nginx", replan_nginx_mock)
-    harness.charm.on.synapse_nginx_pebble_ready.emit(MagicMock())
-    replan_nginx_mock.assert_called_with(nginx_container, "synapse-0.synapse-endpoints")
-
-    harness.update_relation_data(
-        peer_relation_id, harness.charm.app.name, {"main_unit_id": "synapse/1"}
-    )
-
-    replan_nginx_mock.assert_called_with(nginx_container, "synapse-1.synapse-endpoints")
-
-
 def test_scaling_stream_writers_not_configured(harness: Harness) -> None:
     """
     arrange: charm deployed, integrated with Redis and set as leader.
@@ -320,30 +280,3 @@ def test_scaling_worker_name_configured(harness: Harness) -> None:
         content = yaml.safe_load(config_file)
         assert "worker_name" in content
         assert content["worker_name"] == "worker1"
-
-
-def test_scaling_relation_departed(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    arrange: charm deployed, integrated with Redis, two more units in peer relation
-        and set as no leader.
-    act: remove unit from relation.
-    assert: Synapse charm is re-configured.
-    """
-    rel_id = harness.add_relation(synapse.SYNAPSE_PEER_RELATION_NAME, "synapse")
-    harness.add_relation_unit(rel_id, "synapse/1")
-    harness.add_relation_unit(rel_id, "synapse/2")
-    harness.begin_with_initial_hooks()
-    relation = harness.charm.framework.model.get_relation("redis", 0)
-    # We need to bypass protected access to inject the relation data
-    # pylint: disable=protected-access
-    harness.charm._redis._stored.redis_relation = {
-        relation.id: ({"hostname": "redis-host", "port": 1010})
-    }
-    harness.set_leader(False)
-    harness.charm.unit.name = "synapse/1"
-    change_config_mock = MagicMock()
-    monkeypatch.setattr(harness.charm, "change_config", change_config_mock)
-
-    harness.remove_relation_unit(rel_id, "synapse/2")
-
-    change_config_mock.assert_called()

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -38,6 +38,7 @@ class SimpleCharm(CharmBaseWithState):
             media_config=None,
             redis_config=None,
             instance_map_config=None,
+            leader=True,
         )
 
 

--- a/tests/unit/test_irc_bridge.py
+++ b/tests/unit/test_irc_bridge.py
@@ -52,6 +52,7 @@ def charm_state_fixture():
             redis_config=None,
             media_config=None,
             instance_map_config=None,
+            leader=True,
         )
 
     return charm_state_with_db

--- a/tests/unit/test_media_observer.py
+++ b/tests/unit/test_media_observer.py
@@ -170,6 +170,7 @@ def test_enable_media(harness: Harness, relation_data, expected_status, can_conn
         media_config=harness.charm._media.get_relation_as_media_conf(),
         redis_config=None,
         instance_map_config=None,
+        leader=True,
     )
 
     harness.charm._media._enable_media(charm_state)

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -230,6 +230,7 @@ def test_override_rate_limit_success(monkeypatch: pytest.MonkeyPatch):
         media_config=None,
         redis_config=None,
         instance_map_config=None,
+        leader=True,
     )
     expected_url = (
         f"http://localhost:8008/_synapse/admin/v1/users/@any-user:{server}/override_ratelimit"
@@ -267,6 +268,7 @@ def test_override_rate_limit_error(monkeypatch: pytest.MonkeyPatch):
         media_config=None,
         redis_config=None,
         instance_map_config=None,
+        leader=True,
     )
     expected_error_msg = "Failed to connect"
     do_request_mock = mock.MagicMock(side_effect=synapse.APIError(expected_error_msg))

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -255,6 +255,7 @@ def test_enable_trusted_key_servers_no_action(config_content: dict[str, typing.A
             redis_config=None,
             synapse_config=synapse_config,
             instance_map_config=None,
+            leader=True,
         ),
     )
 
@@ -541,6 +542,7 @@ def test_enable_smtp_success(config_content: dict[str, typing.Any]):
         redis_config=None,
         instance_map_config=None,
         synapse_config=synapse_config,
+        leader=True,
     )
 
     synapse.enable_smtp(config_content, charm_state)
@@ -718,6 +720,7 @@ def test_publish_rooms_allowlist_success(config_content: dict[str, typing.Any]):
         synapse_config=synapse_config,
         media_config=None,
         instance_map_config=None,
+        leader=True,
     )
 
     synapse.enable_room_list_publication_rules(config_content, charm_state)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

I know...We already discussed the leadership event, that a leader is guaranteed for 30s but relying on peer relation while Synapse needs to know if is main or worker to define the command to start and then failed to start, peeble restarts the pod.

Well, let's give it a try to force the main unit always to be the leader unit.

Inspiration, reference (all pros and cons are described in the post): https://discourse.charmhub.io/t/leadership-howtos/1123

### Rationale

Deploying Synapse in production shows that if the charm receives many events that trigger restarts (there is no hot reload for Synapse), is hard to control each unit is the main or worker.

### Juju Events Changes

Handle leader-elected and leader-settings-change events

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

No update in docs.
<!-- Explanation for any unchecked items above -->
