### PR TITLE
fix(irc): Point to FQDN

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ops ==2.13.0
 pydantic ==1.10.15
 psycopg2-binary ==2.9.9
 requests == 2.31.0
-boto3 ==1.34.100
+boto3 ==1.34.105
 cosl ==0.0.11
 deepdiff ==7.0.1
 jinja2 ==3.1.4

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -513,7 +513,7 @@ def _get_irc_bridge_config(charm_state: CharmState, db_connect_string: str) -> t
     """
     irc_config_file = Path("templates/irc_bridge_production.yaml").read_text(encoding="utf-8")
     config = yaml.safe_load(irc_config_file)
-    config["homeserver"]["url"] = charm_state.synapse_config.server_name
+    config["homeserver"]["url"] = f"http://{charm_state.synapse_config.server_name}"
     config["homeserver"]["domain"] = charm_state.synapse_config.server_name
     config["database"]["connectionString"] = db_connect_string
     if charm_state.synapse_config.irc_bridge_admins:

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -513,7 +513,7 @@ def _get_irc_bridge_config(charm_state: CharmState, db_connect_string: str) -> t
     """
     irc_config_file = Path("templates/irc_bridge_production.yaml").read_text(encoding="utf-8")
     config = yaml.safe_load(irc_config_file)
-    config["homeserver"]["url"] = f"http://{charm_state.synapse_config.server_name}"
+    config["homeserver"]["url"] = f"https://{charm_state.synapse_config.server_name}"
     config["homeserver"]["domain"] = charm_state.synapse_config.server_name
     config["database"]["connectionString"] = db_connect_string
     if charm_state.synapse_config.irc_bridge_admins:

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -513,7 +513,7 @@ def _get_irc_bridge_config(charm_state: CharmState, db_connect_string: str) -> t
     """
     irc_config_file = Path("templates/irc_bridge_production.yaml").read_text(encoding="utf-8")
     config = yaml.safe_load(irc_config_file)
-    config["homeserver"]["url"] = SYNAPSE_URL
+    config["homeserver"]["url"] = charm_state.synapse_config.server_name
     config["homeserver"]["domain"] = charm_state.synapse_config.server_name
     config["database"]["connectionString"] = db_connect_string
     if charm_state.synapse_config.irc_bridge_admins:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Points to FQDN so that image links work (with the previous SYNAPSE_URL you would get a `localhost` reference that is broken).

<!-- A high level overview of the change -->

### Rationale

No more broken links.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

`src/synapse/workload.py`: in `_get_irc_bridge_config` the `url` now takes the server name from the (charm state) synapse config.
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

n/a
<!-- Any changes to charm libraries -->

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
