### PR TITLE
fix(loki): Use valid key for log files

### DIFF
--- a/src/observability.py
+++ b/src/observability.py
@@ -48,7 +48,7 @@ class Observability:  # pylint: disable=too-few-public-methods
             relation_name="logging",
             logs_scheme={
                 f"{CONTAINER_NAME}": {
-                    "log_files": LOG_PATHS,
+                    "log-files": LOG_PATHS,
                 },
             },
         )


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

One char PR, my favorite - using `log_files` is not valid, if you look (closely) at the docs, it says `log-files`. It fails very silently, though still an user error. This PR fixes that.

<!-- A high level overview of the change -->

### Rationale

Make logs work.
<!-- The reason the change is needed -->

### Juju Events Changes

n/a
<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

`src/observability.py` uses the correct key for logs
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

n/a
<!-- Any changes to charm libraries -->

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
