### PR TITLE
Fix _on_leader_elected and Mjolnir in case of current leader failure

### DIFF
--- a/src-docs/mjolnir.py.md
+++ b/src-docs/mjolnir.py.md
@@ -46,7 +46,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/mjolnir.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/mjolnir.py#L167"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `enable_mjolnir`
 
@@ -94,7 +94,7 @@ Return the current charm.
 
 ---
 
-<a href="../src/mjolnir.py#L145"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/mjolnir.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_membership_room_id`
 

--- a/src/mjolnir.py
+++ b/src/mjolnir.py
@@ -101,7 +101,16 @@ class Mjolnir(ops.Object):  # pylint: disable=too-few-public-methods
             return
         mjolnir_service = container.get_services(MJOLNIR_SERVICE_NAME)
         if mjolnir_service:
-            logger.debug("%s service already exists, skipping", MJOLNIR_SERVICE_NAME)
+            mjolnir_not_active = [
+                service for service in mjolnir_service.values() if not service.is_running()
+            ]
+            if mjolnir_not_active:
+                logger.debug(
+                    "%s service already exists but is not running, restarting",
+                    MJOLNIR_SERVICE_NAME,
+                )
+                container.restart(MJOLNIR_SERVICE_NAME)
+            logger.debug("%s service already exists and running, skipping", MJOLNIR_SERVICE_NAME)
             return
         synapse_service = container.get_services(synapse.SYNAPSE_SERVICE_NAME)
         synapse_not_active = [


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Scenario: leader unit is the main and unexpectedly fails. The relation departed event is not emitted.

This PRs changes the leader_elected event to configure the current leader as the main unit so this will be done in two cases:
- when the charm is deployed
- when the current leader fails and another one is elected

### Rationale

Resiliency.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
There is no charmhub documentation regarding horizontal scaling yet (to be done in different story)