### PR TITLE
Fix Grafana panels and add Prometheus alerts

### DIFF
--- a/src/grafana_dashboards/synapse.json
+++ b/src/grafana_dashboards/synapse.json
@@ -825,6 +825,102 @@
         "yaxis": {
           "align": false
         }
+      },{
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "stepBefore",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 4,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "dark-red",
+                  "value": 0
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 26
+        },
+        "id": 246,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "count_values(\"juju_unit\", up{juju_application=\"synapse\"}) by (juju_model)",
+            "legendFormat": "{{juju_model}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Synapse Units by Juju Model",
+        "type": "timeseries"
       },
       {
         "collapsed": true,

--- a/src/grafana_dashboards/synapse.json
+++ b/src/grafana_dashboards/synapse.json
@@ -452,7 +452,7 @@
               "axisPlacement": "auto",
               "barAlignment": 0,
               "drawStyle": "line",
-              "fillOpacity": 0,
+              "fillOpacity": 10,
               "gradientMode": "none",
               "hideFrom": {
                 "legend": false,
@@ -460,12 +460,12 @@
                 "viz": false
               },
               "lineInterpolation": "linear",
-              "lineWidth": 1,
+              "lineWidth": 3,
               "pointSize": 5,
               "scaleDistribution": {
                 "type": "linear"
               },
-              "showPoints": "auto",
+              "showPoints": "never",
               "spanNulls": false,
               "stacking": {
                 "group": "A",
@@ -475,8 +475,101 @@
                 "mode": "line+area"
               }
             },
+            "links": [],
             "mappings": [],
-            "max": 100,
+            "max": 1.5,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "transparent",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 10
+        },
+        "id": 75,
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": "${prometheusds}",
+            "editorMode": "code",
+            "expr": "rate(process_cpu_user_seconds_total{juju_application=\"synapse\"}[$__rate_interval]) + rate(process_cpu_system_seconds_total{juju_application=\"synapse\"}[$__rate_interval])",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "CPU usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${prometheusds}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 3,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "links": [],
+            "mappings": [],
+            "min": 0,
             "thresholds": {
               "mode": "absolute",
               "steps": [
@@ -490,17 +583,18 @@
                 }
               ]
             },
-            "unit": "percent"
+            "unit": "bytes"
           },
           "overrides": []
         },
         "gridPos": {
-          "h": 8,
+          "h": 9,
           "w": 12,
-          "x": 0,
-          "y": 0
+          "x": 12,
+          "y": 10
         },
-        "id": 256,
+        "id": 198,
+        "links": [],
         "options": {
           "legend": {
             "calcs": [],
@@ -513,124 +607,25 @@
             "sort": "none"
           }
         },
+        "pluginVersion": "9.5.3",
         "targets": [
           {
             "datasource": "${prometheusds}",
             "editorMode": "code",
-            "expr": "rate(process_cpu_seconds_total{juju_charm=\"synapse\"}[$__rate_interval])",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "CPU Usage",
-        "type": "timeseries"
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "${prometheusds}",
-        "editable": true,
-        "error": false,
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 1,
-        "fillGradient": 0,
-        "grid": {},
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 10
-        },
-        "hiddenSeries": false,
-        "id": 198,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 3,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "paceLength": 10,
-        "percentage": false,
-        "pluginVersion": "9.2.2",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": "${prometheusds}",
-            "expr": "process_resident_memory_bytes{instance=\"$instance\",job=~\"$job\",index=~\"$index\"}",
+            "expr": "jemalloc_stats_app_memory_bytes{juju_application=\"synapse\",type=\"mapped\"}",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 2,
             "legendFormat": "{{job}} {{index}}",
+            "range": true,
             "refId": "A",
             "step": 20,
             "target": ""
-          },
-          {
-            "datasource": "${prometheusds}",
-            "expr": "sum(process_resident_memory_bytes{instance=\"$instance\",job=~\"$job\",index=~\"$index\"})",
-            "hide": true,
-            "interval": "",
-            "legendFormat": "total",
-            "refId": "B"
           }
         ],
-        "thresholds": [],
-        "timeRegions": [],
         "title": "Memory",
-        "tooltip": {
-          "shared": false,
-          "sort": 0,
-          "value_type": "cumulative"
-        },
         "transformations": [],
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:1560",
-            "format": "bytes",
-            "logBase": 1,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:1561",
-            "format": "short",
-            "logBase": 1,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
+        "type": "timeseries"
       },
       {
         "datasource": "${prometheusds}",

--- a/src/prometheus_alert_rules/synapse.rule
+++ b/src/prometheus_alert_rules/synapse.rule
@@ -67,3 +67,17 @@ groups:
     annotations:
       summary: Synapse _process_new_pulled_events_with_failed_pull_attempts process CPU usage had an increase bigger than 1% \n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}
       description: Synapse _process_new_pulled_events_with_failed_pull_attempts process CPU usage had an increase bigger than 1%. Verify CPU usage and logs to find the room triggering this.
+  - alert: SynapseUnitsChanged
+    expr: changes(count_values("juju_unit", up{juju_charm="synapse"}) by (juju_model)[5m:1m]) > 0
+    labels:
+      severity: critical
+    annotations:
+      summary: Synapse number of units has changed. \n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}
+      description: Verify if Synapse was scaled (up or down) or if units are missing.
+  - alert: SynapseHighEventRate
+    expr: rate(synapse_storage_events_persisted_by_event_type[2m]) > 0.6
+    labels:
+      severity: warning
+    annotations:
+      summary: High rate per second of Synapse events (> 600). \n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}
+      description: This could indicate a possible hiccup (especially for events m.room.member or m.room.power_levels)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR:
- Fix CPU usage and Memory panels
- Add panel Synapse Units by Juju Model
- Add SynapseUnitsChanged and SynapseHighEventRate alerts

![grafana_dashboard_synapse](https://github.com/canonical/synapse-operator/assets/12564014/b1e35ac1-125f-4297-b698-043886a32dbb)


### Rationale

Improve monitoring considering horizontal scaling.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No charmhub doc for horizontal scaling yet.