### PR TITLE
fix: fix call to override_ratelimit

### DIFF
--- a/src/synapse/api.py
+++ b/src/synapse/api.py
@@ -373,7 +373,7 @@ def override_rate_limit(user: User, admin_access_token: str, charm_state: CharmS
         f"{SYNAPSE_URL}/_synapse/admin/v1/users/"
         f"@{user.username}:{server_name}/override_ratelimit"
     )
-    _do_request("DELETE", rate_limit_url, admin_access_token=admin_access_token)
+    _do_request("POST", rate_limit_url, admin_access_token=admin_access_token)
 
 
 def get_room_id(

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -241,7 +241,7 @@ def test_override_rate_limit_success(monkeypatch: pytest.MonkeyPatch):
     )
 
     do_request_mock.assert_called_once_with(
-        "DELETE", expected_url, admin_access_token=admin_access_token
+        "POST", expected_url, admin_access_token=admin_access_token
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

The call to override_ratelimit already exists but for some misunderstanding, it was called with DELETE instead of POST.

### Rationale

This PR fixes the call so an override_rate limit is added to Mjolnir user.

References: 
https://github.com/matrix-org/synapse/issues/6286
https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#set-ratelimit

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
