### PR TITLE
fix: add rustup snap

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,8 +14,10 @@ bases:
       channel: "22.04"
 parts:
   charm:
-    build-packages:
-    - cargo
-    - rustc
+    build-snaps:
+      - rustup
+    override-build: |
+      rustup default stable
+      craftctl default
     charm-binary-python-packages:
     - psycopg2-binary==2.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ops ==2.15.0
 pydantic ==1.10.17
 psycopg2-binary ==2.9.9
 requests ==2.32.3
+rpds-py ==0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ ops ==2.15.0
 pydantic ==1.10.17
 psycopg2-binary ==2.9.9
 requests ==2.32.3
-rpds-py ==0.18.1


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Charmcraft pack throws the following error:

```
 2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.493 ::    ::   × Building wheel for rpds-py (pyproject.toml) did not run successfully.
  2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.493 ::    ::   │ exit code: 1
  2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.493 ::    ::   ╰─> [13 lines of output]
  2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.494 ::    ::       Running `maturin pep517 build-wheel -i /root/parts/charm/build/staging-venv/bin/python3 --compatibility off`
  2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.494 ::    ::       📦 Including license file "/tmp/pip-install-1i7phoq9/rpds-py_e2f441b374f04c92932669e3b4817ee9/LICENSE"
  2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.494 ::    ::       🔗 Found pyo3 bindings
  2024-08-01 14:12:59.657 :: 2024-08-01 14:12:57.494 ::    ::       🐍 Found CPython 3.10 at /root/parts/charm/build/staging-venv/bin/python3
  2024-08-01 14:12:59.658 :: 2024-08-01 14:12:57.494 ::    ::       📡 Using build options features from pyproject.toml
  2024-08-01 14:12:59.658 :: 2024-08-01 14:12:57.494 ::    ::       error: package `triomphe v0.1.13` cannot be built because it requires rustc 1.76 or newer, while the currently active rustc version is 1.75.0
  2024-08-01 14:12:59.658 :: 2024-08-01 14:12:57.494 ::    ::       Either upgrade to rustc 1.76 or newer, or use
```


### Rationale

Add rustup snap to fix this requirement. Thanks @yanksyoon  !

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
