### PR TITLE
fix: replace CPU panel percent view by time view

### DIFF
--- a/src/grafana_dashboards/synapse.json
+++ b/src/grafana_dashboards/synapse.json
@@ -439,7 +439,11 @@
         }
       },
       {
-        "datasource": "${prometheusds}",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "Average user and system CPU time spent in seconds.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -448,7 +452,6 @@
             "custom": {
               "axisCenteredZero": false,
               "axisColorMode": "text",
-              "axisLabel": "",
               "axisPlacement": "auto",
               "barAlignment": 0,
               "drawStyle": "line",
@@ -475,9 +478,9 @@
                 "mode": "line+area"
               }
             },
+            "displayName": "CPU Time",
             "links": [],
             "mappings": [],
-            "max": 1.5,
             "min": 0,
             "thresholds": {
               "mode": "absolute",
@@ -485,14 +488,10 @@
                 {
                   "color": "transparent",
                   "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 1
                 }
               ]
             },
-            "unit": "percentunit"
+            "unit": "s"
           },
           "overrides": []
         },
@@ -506,7 +505,12 @@
         "links": [],
         "options": {
           "legend": {
-            "calcs": [],
+            "calcs": [
+              "min",
+              "max",
+              "mean",
+              "lastNotNull"
+            ],
             "displayMode": "list",
             "placement": "bottom",
             "showLegend": true
@@ -521,8 +525,11 @@
           {
             "datasource": "${prometheusds}",
             "editorMode": "code",
-            "expr": "rate(process_cpu_user_seconds_total{juju_application=\"synapse\"}[$__rate_interval]) + rate(process_cpu_system_seconds_total{juju_application=\"synapse\"}[$__rate_interval])",
-            "legendFormat": "__auto",
+            "expr": "avg(rate(process_cpu_seconds_total{instance=\"$instance\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]) * 1000)",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{job}}-{{index}} ",
             "range": true,
             "refId": "A"
           }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Changes the CPU usage panel by considering time instead of percent, preventing confusion while monitoring Synapse.

Now similar to the one done by the PostgreSQL charm.

![Screenshot from 2024-08-26 16-24-42](https://github.com/user-attachments/assets/75bf5475-373b-4db5-a217-4aa8d76a422f)


### Rationale

CPU percent was given a unexpected result.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
