### PR TITLE
feat: add limit_remote_rooms_complexity configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,10 @@ options:
       Comma separated list of IP address CIDR ranges that should be allowed for
       federation, identity servers, push servers, and for checking key validity
       for third-party invite events.
+  limit_remote_rooms_complexity:
+    type: float
+    description: if set, the room "complexity" will be checked before a user
+      joins a new remote room.
   notif_from:
     type: string
     description: defines the "From" address to use when sending emails.

--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,8 @@ options:
   limit_remote_rooms_complexity:
     type: float
     description: if set, the room "complexity" will be checked before a user
-      joins a new remote room.
+      joins a new remote room. If the complexity is higher, the user will not be
+      able to join the room.
   notif_from:
     type: string
     description: defines the "From" address to use when sending emails.

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -191,7 +191,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L349"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L351"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -284,6 +284,7 @@ Represent Synapse builtin configuration values.
  - <b>`enable_room_list_search`</b>:  enable_room_list_search config. 
  - <b>`federation_domain_whitelist`</b>:  federation_domain_whitelist config. 
  - <b>`ip_range_whitelist`</b>:  ip_range_whitelist config. 
+ - <b>`limit_remote_rooms_complexity`</b>:  limit_remote_rooms_complexity config. 
  - <b>`notif_from`</b>:  defines the "From" address to use when sending emails. 
  - <b>`public_baseurl`</b>:  public_baseurl config. 
  - <b>`publish_rooms_allowlist`</b>:  publish_rooms_allowlist config. 
@@ -300,7 +301,7 @@ Represent Synapse builtin configuration values.
 
 ---
 
-<a href="../src/charm_state.py#L210"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `get_default_notif_from`
 
@@ -324,7 +325,7 @@ Set server_name as default value to notif_from.
 
 ---
 
-<a href="../src/charm_state.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_pebble_check`
 
@@ -353,7 +354,7 @@ Convert the experimental_alive_check field to pebble check.
 
 ---
 
-<a href="../src/charm_state.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L231"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_yes_or_no`
 
@@ -376,7 +377,7 @@ Convert the report_stats field to yes or no.
 
 ---
 
-<a href="../src/charm_state.py#L244"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L246"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `userids_to_list`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -191,7 +191,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L351"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L352"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -301,7 +301,7 @@ Represent Synapse builtin configuration values.
 
 ---
 
-<a href="../src/charm_state.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L213"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `get_default_notif_from`
 
@@ -325,7 +325,7 @@ Set server_name as default value to notif_from.
 
 ---
 
-<a href="../src/charm_state.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L272"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_pebble_check`
 
@@ -354,7 +354,7 @@ Convert the experimental_alive_check field to pebble check.
 
 ---
 
-<a href="../src/charm_state.py#L231"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_yes_or_no`
 
@@ -377,7 +377,7 @@ Convert the report_stats field to yes or no.
 
 ---
 
-<a href="../src/charm_state.py#L246"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L247"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `userids_to_list`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -237,7 +237,7 @@ This is the main entry for changes that require a restart done via Pebble.
 
 ---
 
-<a href="../src/pebble.py#L369"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L374"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -166,6 +166,7 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
         enable_room_list_search: enable_room_list_search config.
         federation_domain_whitelist: federation_domain_whitelist config.
         ip_range_whitelist: ip_range_whitelist config.
+        limit_remote_rooms_complexity: limit_remote_rooms_complexity config.
         notif_from: defines the "From" address to use when sending emails.
         public_baseurl: public_baseurl config.
         publish_rooms_allowlist: publish_rooms_allowlist config.
@@ -183,16 +184,17 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
     enable_mjolnir: bool = False
     enable_password_config: bool = True
     enable_room_list_search: bool = True
+    experimental_alive_check: str | None = Field(None)
     federation_domain_whitelist: str | None = Field(None)
     ip_range_whitelist: str | None = Field(None, regex=r"^[\.:,/\d]+\d+(?:,[:,\d]+)*$")
+    limit_remote_rooms_complexity: float | None = Field(None)
+    notif_from: str | None = Field(None)
     public_baseurl: str | None = Field(None)
     publish_rooms_allowlist: str | None = Field(None)
-    experimental_alive_check: str | None = Field(None)
     rc_joins_remote_burst_count: int | None = Field(None)
     rc_joins_remote_per_second: float | None = Field(None)
     report_stats: str | None = Field(None)
     server_name: str = Field(..., min_length=2)
-    notif_from: str | None = Field(None)
     trusted_key_servers: str | None = Field(
         None, regex=r"^[A-Za-z0-9][A-Za-z0-9-.]*(?:,[A-Za-z0-9][A-Za-z0-9-.]*)*\.\D{2,4}$"
     )

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -188,13 +188,14 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
     federation_domain_whitelist: str | None = Field(None)
     ip_range_whitelist: str | None = Field(None, regex=r"^[\.:,/\d]+\d+(?:,[:,\d]+)*$")
     limit_remote_rooms_complexity: float | None = Field(None)
-    notif_from: str | None = Field(None)
     public_baseurl: str | None = Field(None)
     publish_rooms_allowlist: str | None = Field(None)
     rc_joins_remote_burst_count: int | None = Field(None)
     rc_joins_remote_per_second: float | None = Field(None)
     report_stats: str | None = Field(None)
     server_name: str = Field(..., min_length=2)
+    # notif_from should be after server_name because of how the validator is set.
+    notif_from: str | None = Field(None)
     trusted_key_servers: str | None = Field(
         None, regex=r"^[A-Za-z0-9][A-Za-z0-9-.]*(?:,[A-Za-z0-9][A-Za-z0-9-.]*)*\.\D{2,4}$"
     )

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -298,6 +298,11 @@ def reconcile(  # noqa: C901 pylint: disable=too-many-branches,too-many-statemen
         synapse.enable_rc_joins_remote_rate(current_synapse_config, charm_state=charm_state)
         synapse.enable_serve_server_wellknown(current_synapse_config)
         synapse.enable_replication(current_synapse_config)
+        if charm_state.synapse_config.limit_remote_rooms_complexity:
+            logger.debug("pebble.change_config: Enabling limit_remote_rooms_complexity")
+            synapse.enable_limit_remote_rooms_complexity(
+                current_synapse_config, charm_state=charm_state
+            )
         if charm_state.instance_map_config is not None:
             logger.debug("pebble.change_config: Enabling instance_map")
             synapse.enable_instance_map(current_synapse_config, charm_state=charm_state)

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -78,6 +78,7 @@ from .workload_configuration import (  # noqa: F401
     enable_forgotten_room_retention,
     enable_instance_map,
     enable_ip_range_whitelist,
+    enable_limit_remote_rooms_complexity,
     enable_media,
     enable_media_retention,
     enable_metrics,

--- a/src/synapse/workload_configuration.py
+++ b/src/synapse/workload_configuration.py
@@ -129,6 +129,20 @@ def enable_ip_range_whitelist(current_yaml: dict, charm_state: CharmState) -> No
         raise WorkloadError(str(exc)) from exc
 
 
+def enable_limit_remote_rooms_complexity(current_yaml: dict, charm_state: CharmState) -> None:
+    """Enable limit_remote_rooms complexity.
+
+    Args:
+        current_yaml: current configuration.
+        charm_state: Instance of CharmState.
+    """
+    limit_remote_rooms = {
+        "enabled": True,
+        "complexity": charm_state.synapse_config.limit_remote_rooms_complexity,
+    }
+    current_yaml["limit_remote_rooms"] = limit_remote_rooms
+
+
 def enable_media(current_yaml: dict, charm_state: CharmState) -> None:
     """Change the Synapse configuration to enable S3.
 

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -781,3 +781,27 @@ def test_enable_rc_joins_remote_rate(
         "rc_joins": {"remote": {"burst_count": 10, "per_second": 0.2}},
     }
     assert yaml.safe_dump(config) == yaml.safe_dump(expected_config_content)
+
+
+def test_enable_limit_remote_rooms_complexity(
+    harness: Harness,
+    config_content: dict[str, typing.Any],
+):
+    """
+    arrange: set mock container with file.
+    act: update limit_remote_rooms_complexity config and call limit_remote_rooms_complexity.
+    assert: new configuration file is pushed and limit_remote_rooms_complexity is enabled.
+    """
+    config = config_content
+
+    harness.update_config({"limit_remote_rooms_complexity": 0.2})
+    harness.begin()
+    synapse.enable_limit_remote_rooms_complexity(config, harness.charm.build_charm_state())
+
+    expected_config_content = {
+        "listeners": [
+            {"type": "http", "port": 8080, "bind_addresses": ["::"]},
+        ],
+        "limit_remote_rooms": {"enabled": True, "complexity": 0.2},
+    }
+    assert yaml.safe_dump(config) == yaml.safe_dump(expected_config_content)

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0
@@ -59,7 +59,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR adds a new configuration limit_remote_rooms_complexity that prevents a user from joining rooms with a complexity bigger than the one set.

### Rationale

Prevent performance issues by limiting remote complex rooms.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
