### PR TITLE
fix: split prometheus targets into two jobs

### DIFF
--- a/src/grafana_dashboards/synapse.json
+++ b/src/grafana_dashboards/synapse.json
@@ -439,103 +439,109 @@
         }
       },
       {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${prometheusds}"
-        },
-        "description": "Average user and system CPU time spent in seconds/second.",
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "${prometheusds}",
         "fieldConfig": {
           "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 10,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 3,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "line+area"
-              }
-            },
-            "displayName": "CPU Time",
-            "links": [],
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "transparent",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "s"
+            "displayName": "CPU usage",
+            "links": []
           },
           "overrides": []
         },
+        "fill": 1,
+        "fillGradient": 0,
         "gridPos": {
           "h": 9,
           "w": 12,
           "x": 0,
           "y": 10
         },
+        "hiddenSeries": false,
         "id": 75,
-        "links": [],
-        "options": {
-          "legend": {
-            "calcs": [
-              "min",
-              "max",
-              "mean",
-              "lastNotNull"
-            ],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
+        "legend": {
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": true
         },
+        "lines": true,
+        "linewidth": 3,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "paceLength": 10,
+        "percentage": false,
         "pluginVersion": "9.5.3",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
         "targets": [
           {
             "datasource": "${prometheusds}",
-            "editorMode": "code",
-            "expr": "avg(rate(process_cpu_seconds_total{instance=\"$instance\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$bucket_size]))",
+            "expr": "rate(process_cpu_seconds_total{job=~\".*synapse_application.*\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$bucket_size])",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
             "legendFormat": "{{job}}-{{index}} ",
-            "range": true,
             "refId": "A"
           }
         ],
+        "thresholds": [
+          {
+            "$$hashKey": "object:566",
+            "colorMode": "critical",
+            "fill": true,
+            "line": true,
+            "op": "gt",
+            "value": 1,
+            "yaxis": "left"
+          }
+        ],
+        "timeRegions": [],
         "title": "CPU usage",
-        "type": "timeseries"
+        "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:538",
+            "format": "percentunit",
+            "label": "",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:539",
+            "format": "short",
+            "label": "",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "datasource": "${prometheusds}",

--- a/src/observability.py
+++ b/src/observability.py
@@ -27,14 +27,25 @@ class Observability:  # pylint: disable=too-few-public-methods
         self._grafana_dashboards = GrafanaDashboardProvider(
             charm, relation_name="grafana-dashboard"
         )
-        self.targets = [
+        synapse_target = [
             f"*:{synapse.SYNAPSE_EXPORTER_PORT}",
+        ]
+        synapse_stats_target = [
             f"*:{synapse.STATS_EXPORTER_PORT}",
         ]
         self._metrics_endpoint = MetricsEndpointProvider(
             charm,
             relation_name="metrics-endpoint",
-            jobs=[{"static_configs": [{"targets": self.targets}]}],
+            jobs=[
+                {
+                    "job_name": "synapse_application",
+                    "static_configs": [{"targets": synapse_target}],
+                },
+                {
+                    "job_name": "synapse_stats_exporter",
+                    "static_configs": [{"targets": synapse_stats_target}],
+                },
+            ],
         )
         self._logging = LogProxyConsumer(
             charm,

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -22,14 +22,25 @@ def test_prometheus_target(prometheus_configured: Harness) -> None:
 
     assert harness.charm._observability._metrics_endpoint._scrape_jobs == [
         {
+            "job_name": "synapse_application",
             "metrics_path": "/metrics",
             "static_configs": [
                 {
                     "targets": [
                         f"*:{synapse.SYNAPSE_EXPORTER_PORT}",
+                    ]
+                }
+            ],
+        },
+        {
+            "job_name": "synapse_stats_exporter",
+            "metrics_path": "/metrics",
+            "static_configs": [
+                {
+                    "targets": [
                         f"*:{synapse.STATS_EXPORTER_PORT}",
                     ]
                 }
             ],
-        }
+        },
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0
@@ -59,7 +59,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
…nds_total duplication

<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

After creating a theory connecting multiple cores to the unusually high values for process_cpu_seconds_total, it turns out the real cause was two Prometheus targets with the same metrics and labels.

### Rationale

This PR fixes that by splitting the targets into two jobs and revert changes in Grafana dashboard to show CPU usage as %.

Screenshot

![image](https://github.com/user-attachments/assets/95a3e172-5a1d-470e-9d5c-ca114eed54b4)


<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
