### PR TITLE
fix: stop Mjolnir if is running in a worker unit

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,7 @@ jobs:
       extra-arguments: -x --localstack-address 172.17.0.1
       pre-run-script: localstack-installation.sh
       trivy-image-config: "trivy.yaml"
-      juju-channel: 3.1/stable
+      juju-channel: 3.4/stable
       channel: 1.28-strict/stable
       modules: '["test_charm", "test_nginx", "test_s3", "test_scaling"]'
       self-hosted-runner: false

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,7 +15,6 @@ maintainers:
 source: https://github.com/canonical/synapse-operator
 assumes:
   - k8s-api
-  - juju >= 3.1
 
 containers:
   synapse:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,7 @@ maintainers:
 source: https://github.com/canonical/synapse-operator
 assumes:
   - k8s-api
+  - juju >= 3.1
 
 containers:
   synapse:

--- a/src-docs/mjolnir.py.md
+++ b/src-docs/mjolnir.py.md
@@ -46,7 +46,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/mjolnir.py#L167"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/mjolnir.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `enable_mjolnir`
 
@@ -94,7 +94,7 @@ Return the current charm.
 
 ---
 
-<a href="../src/mjolnir.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/mjolnir.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_membership_room_id`
 

--- a/src-docs/mjolnir.py.md
+++ b/src-docs/mjolnir.py.md
@@ -46,7 +46,7 @@ Shortcut for more simple access the model.
 
 ---
 
-<a href="../src/mjolnir.py#L172"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/mjolnir.py#L171"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `enable_mjolnir`
 
@@ -94,7 +94,7 @@ Return the current charm.
 
 ---
 
-<a href="../src/mjolnir.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/mjolnir.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_membership_room_id`
 

--- a/src/mjolnir.py
+++ b/src/mjolnir.py
@@ -100,7 +100,6 @@ class Mjolnir(ops.Object):  # pylint: disable=too-few-public-methods
             if not self._charm.unit.name == main_unit_id:
                 if mjolnir_service:
                     logger.info("This is not the main unit, stopping Mjolnir")
-                    print(container.stop())
                     container.stop(MJOLNIR_SERVICE_NAME)
                 else:
                     logger.info("This is not the main unit, skipping Mjolnir configuration")


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Mjolnir should run only in the main unit but when it changes, it keeps running in the previous one.

### Rationale

This PR guarantees that Mjolnir is not configured and is stopped in the worker units if enabled.

### Juju Events Changes

Collec status.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
