### PR TITLE
Add support for block non admin invites

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,12 @@ options:
   backup_passphrase:
     type: string
     description: Passphrase used to encrypt a backup using gpg with symmetric key.
+  block_non_admin_invites:
+    type: boolean
+    default: false
+    description: |
+      When enabled, room invites to users on this server will be blocked
+      (except those sent by local server admins).
   enable_email_notifs:
     type: boolean
     default: false

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -191,7 +191,7 @@ Get charm proxy information from juju charm environment.
 
 ---
 
-<a href="../src/charm_state.py#L352"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L354"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -278,6 +278,7 @@ Represent Synapse builtin configuration values.
 **Attributes:**
  
  - <b>`allow_public_rooms_over_federation`</b>:  allow_public_rooms_over_federation config. 
+ - <b>`block_non_admin_invites`</b>:  block_non_admin_invites config. 
  - <b>`enable_email_notifs`</b>:  enable_email_notifs config. 
  - <b>`enable_mjolnir`</b>:  enable_mjolnir config. 
  - <b>`enable_password_config`</b>:  enable_password_config config. 
@@ -301,7 +302,7 @@ Represent Synapse builtin configuration values.
 
 ---
 
-<a href="../src/charm_state.py#L213"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L215"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `get_default_notif_from`
 
@@ -325,7 +326,7 @@ Set server_name as default value to notif_from.
 
 ---
 
-<a href="../src/charm_state.py#L272"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L274"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_pebble_check`
 
@@ -354,7 +355,7 @@ Convert the experimental_alive_check field to pebble check.
 
 ---
 
-<a href="../src/charm_state.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `to_yes_or_no`
 
@@ -377,7 +378,7 @@ Convert the report_stats field to yes or no.
 
 ---
 
-<a href="../src/charm_state.py#L247"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L249"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `userids_to_list`
 

--- a/src-docs/pebble.py.md
+++ b/src-docs/pebble.py.md
@@ -237,7 +237,7 @@ This is the main entry for changes that require a restart done via Pebble.
 
 ---
 
-<a href="../src/pebble.py#L374"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/pebble.py#L377"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `reset_instance`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -160,6 +160,7 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
 
     Attributes:
         allow_public_rooms_over_federation: allow_public_rooms_over_federation config.
+        block_non_admin_invites: block_non_admin_invites config.
         enable_email_notifs: enable_email_notifs config.
         enable_mjolnir: enable_mjolnir config.
         enable_password_config: enable_password_config config.
@@ -180,6 +181,7 @@ class SynapseConfig(BaseModel):  # pylint: disable=too-few-public-methods
     """
 
     allow_public_rooms_over_federation: bool = False
+    block_non_admin_invites: bool = False
     enable_email_notifs: bool = False
     enable_mjolnir: bool = False
     enable_password_config: bool = True

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -291,6 +291,9 @@ def reconcile(  # noqa: C901 pylint: disable=too-many-branches,too-many-statemen
             synapse.execute_migrate_config(container=container, charm_state=charm_state)
         existing_synapse_config = _get_synapse_config(container)
         current_synapse_config = _get_synapse_config(container)
+        if charm_state.synapse_config.block_non_admin_invites:
+            logger.debug("pebble.change_config: Enabling Block non admin invites")
+            synapse.block_non_admin_invites(current_synapse_config, charm_state=charm_state)
         synapse.enable_metrics(current_synapse_config)
         synapse.enable_forgotten_room_retention(current_synapse_config)
         synapse.enable_media_retention(current_synapse_config)

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -70,6 +70,7 @@ from .workload import (  # noqa: F401
     validate_config,
 )
 from .workload_configuration import (  # noqa: F401
+    block_non_admin_invites,
     disable_password_config,
     disable_room_list_search,
     enable_allow_public_rooms_over_federation,

--- a/src/synapse/workload_configuration.py
+++ b/src/synapse/workload_configuration.py
@@ -51,6 +51,16 @@ def disable_room_list_search(current_yaml: dict) -> None:
     current_yaml["enable_room_list_search"] = False
 
 
+def block_non_admin_invites(current_yaml: dict, charm_state: CharmState) -> None:
+    """Change the Synapse configuration to block non admin room invitations.
+
+    Args:
+        current_yaml: current configuration.
+        charm_state: Instance of CharmState.
+    """
+    current_yaml["block_non_admin_invites"] = charm_state.synapse_config.block_non_admin_invites
+
+
 def enable_allow_public_rooms_over_federation(current_yaml: dict) -> None:
     """Change the Synapse configuration to allow public rooms in federation.
 

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -695,6 +695,39 @@ def test_http_proxy(
         assert env.get(env_name) == env.get(env_name.upper()) == env_value
 
 
+def test_block_non_admin_invites(config_content: dict[str, typing.Any]):
+    """
+    arrange: set mock container with file.
+    act: update block_non_admin_invites config to true.
+    assert: new configuration file is pushed and block_non_admin_invites is enabled.
+    """
+    block_non_admin_invites = {
+        "block_non_admin_invites": True,
+        "server_name": "example.com",
+    }
+    synapse_config = SynapseConfig(**block_non_admin_invites)  # type: ignore[arg-type]
+    charm_state = CharmState(
+        datasource=None,
+        saml_config=None,
+        smtp_config=SMTP_CONFIGURATION,
+        redis_config=None,
+        synapse_config=synapse_config,
+        media_config=None,
+        instance_map_config=None,
+    )
+
+    synapse.block_non_admin_invites(config_content, charm_state)
+
+    expected_config_content = {
+        "block_non_admin_invites": True,
+        "listeners": [
+            {"type": "http", "port": 8080, "bind_addresses": ["::"]},
+        ],
+    }
+
+    assert yaml.safe_dump(config_content) == yaml.safe_dump(expected_config_content)
+
+
 def test_publish_rooms_allowlist_success(config_content: dict[str, typing.Any]):
     """
     arrange: mock Synapse current configuration with config_content and


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Add the possibility for a charm operator to enable the `block_non_admin_invite` option on Synapse
See documentation: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html?highlight=block_non_ad#block_non_admin_invites

### Rationale

Following a SPAM attack on our Ubuntu community matrix server where the spammer is creating rooms in other servers than our homeserver and sending invites to these rooms containing NFSW content, we decided to add this option in order to enable it in case of "emergency" situation.

### Juju Events Changes

N/A

### Module Changes

Added a charm config option, reflected in CharmState.
Added a Synapse Workload method to add this configuration option into Synapse homeserver.yaml file.

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
