### PR TITLE
fix: get new invite checker module version

### DIFF
--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -115,6 +115,7 @@ parts:
             pip3 install --prefix="/install" --no-deps --no-warn-script-location /synapse[all];
             git clone https://git.buechner.me/nbuechner/synapse-invite-checker
             cd synapse-invite-checker
+            git checkout e81f3087924038ff23d7ee15e9b992631ea593d0
             pip3 install --prefix="/install" --no-warn-script-location -U .
             cd ..
             cp docker/start.py $CRAFT_PART_INSTALL/


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR updates Synapse rock by getting new version of the invite checker module that supports proxy usage.

### Rationale

Use invite checker module with proxy.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
