### PR TITLE
fix: replace deprecated ops.main.main for ops.main

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -14,8 +14,8 @@ import ops
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.redis_k8s.v0.redis import RedisRelationCharmEvents
 from charms.traefik_k8s.v1.ingress import IngressPerAppRequirer
+from ops import main
 from ops.charm import ActionEvent, RelationDepartedEvent
-from ops.main import main
 
 import actions
 import pebble


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Remove deprecated ops.main.main
https://ops.readthedocs.io/en/latest/#ops-main-entry-point

### Rationale

Use new one ops.main

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
