### PR TITLE
fix: fix synapse units panel

### DIFF
--- a/src/grafana_dashboards/synapse.json
+++ b/src/grafana_dashboards/synapse.json
@@ -926,7 +926,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "count_values(\"juju_unit\", up{juju_application=\"synapse\"}) by (juju_model)",
+            "expr": "count(up{juju_application=\"synapse\", job=~\".*prometheus_scrape_synapse_application.*\", juju_model=~\"$juju_model\"}) by (juju_model)",
             "legendFormat": "{{juju_model}}",
             "range": true,
             "refId": "A"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR changes Prometheus query for counting the number of active units for each model.

![image](https://github.com/user-attachments/assets/472c4a9c-3537-492c-a7fa-d3ee00c3c06c)

### Rationale

The previous one was counting series with the job related to the synapse-stats-exporter, resulting in a number different than the expected.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
