### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
       "fileMatch": ["(^|/)rockcraft.yaml$"],
       "description": "Update Synapse workload",
       "matchStringsStrategy": "any",
-      "matchStrings": ["source-tag: v(?<currentValue>.+)"],
+      "matchStrings": ["source-tag: (?<currentValue>.+)"],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "element-hq/synapse",
       "versioningTemplate": "semver-coerced"


### PR DESCRIPTION
Fix problems like with this commit: https://github.com/canonical/synapse-operator/pull/606/commits/af0c59e4d762da46053108674c9c40020e16ec5e

The source tag that renovate is tracking now includes the `v`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
