### PR TITLE
ISD-2808 don't set node_env=dev

### DIFF
--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -198,16 +198,14 @@ parts:
     source-subdir: frontend
     build-environment:
       - NODE_URI: "https://nodejs.org/dist/v22.11.0/node-v22.11.0-linux-x64.tar.gz"
-      - NODE_ENV: dev
     override-build: |
       curl -Ls $NODE_URI | tar xzf - -C /usr/ --skip-old-files --no-same-owner --strip-components=1
-      npm --prefix=$CRAFT_PART_BUILD/frontend ci
-      npm --prefix=$CRAFT_PART_BUILD/frontend run build
+      (cd $CRAFT_PART_BUILD/frontend; npm ci; npm run build)
       mkdir -p $CRAFT_PART_INSTALL/mas/share/assets
-      cp -r frontend/dist/* $CRAFT_PART_INSTALL/mas/share/assets/
       cp frontend/dist/manifest.json $CRAFT_PART_INSTALL/mas/share/manifest.json
+      cp -r frontend/dist/ $CRAFT_PART_INSTALL/mas/share/assets
     stage:
-      - mas/*
+      - mas/share/*
   mas-cli:
     plugin: rust
     rust-channel: stable


### PR DESCRIPTION
Setting node_env = dev when building the charm causes the assets to be incorrectly built. This PR simply removes that build environment and also do some refactoring of the mas-assets part

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
