### PR TITLE
Integrate Allure with Synapse

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,9 @@ name: Integration tests
 
 on:
   pull_request:
+  schedule:
+    # Trigger at 6:00 AM and 6:00 PM UTC
+    - cron: "0 6,18 * * *"
 
 jobs:
   integration-tests:
@@ -14,3 +17,8 @@ jobs:
       juju-channel: 3.4/stable
       channel: 1.28-strict/stable
       modules: '["test_charm", "test_nginx", "test_s3", "test_scaling", "test_matrix_auth"]'
+  allure-report:
+    if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+    needs:
+      - integration-tests
+    uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psycopg2-binary ==2.9.10
 pydantic ==2.10.3
 python-ulid ==3.0.0
 requests ==2.32.3
+allure-pytest>=2.8.18

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ deps =
     boto3
     # Type error problem with newer version of macaroonbakery
     macaroonbakery==1.3.2
-    git+https://github.com/canonical/operator-workflows@main\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
+    git+https://github.com/canonical/data-platform-workflows@v24.0.0\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v -x --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -125,6 +125,7 @@ deps =
     boto3
     # Type error problem with newer version of macaroonbakery
     macaroonbakery==1.3.2
+    git+https://github.com/canonical/operator-workflows@main\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v -x --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Integrating Allure Reports with Synpase. This will visualise the statistics obtained from running integration tests at given intervals. More information regrarding the integration - [How to integrate Allure](https://github.com/canonical/operator-workflows/blob/main/docs/how-to/integration_test_allure.md)
<!-- A high level overview of the change -->

### Rationale

To better understand why integration tests are failing in synapse.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
