### PR TITLE
update docs and wrap pebble.ExecError with custom error

### DIFF
--- a/docs/explanation/moderation-and-spam-control.md
+++ b/docs/explanation/moderation-and-spam-control.md
@@ -59,5 +59,4 @@ For details and implementation, visit the module’s repository: [Synapse Invite
 ---
 
 ## Mjolnir
-
-With the arrival of MAS mjolnir has been temporary disabled.
+With the arrival of MAS, mjolnir has been temporary disabled.

--- a/src/auth/mas.py
+++ b/src/auth/mas.py
@@ -16,7 +16,6 @@ from state.mas import MASConfiguration
 logger = logging.getLogger()
 
 MAS_TEMPLATE_FILE_NAME = "mas_config.yaml.j2"
-
 MAS_SERVICE_NAME = "synapse-mas"
 MAS_EXECUTABLE_PATH = "/usr/bin/mas-cli"
 MAS_WORKING_DIR = "/mas"
@@ -46,12 +45,20 @@ class MASConfigInvalidError(Exception):
     """Exception raised when validation of the MAS config failed."""
 
 
+class MASConfigSyncError(Exception):
+    """Exception raised when synchronisation of the MAS config failed."""
+
+
 class MASRegisterUserFailedError(Exception):
     """Exception raised when validation of the MAS config failed."""
 
 
 class MASVerifyUserEmailFailedError(Exception):
     """Exception raised when validation of the MAS config failed."""
+
+
+class MASDeactivateUserFailedError(Exception):
+    """Exception raised when deactivation of a MAS user failed."""
 
 
 class MASGenerateAdminAccessTokenError(Exception):
@@ -63,10 +70,18 @@ def validate_mas_config(container: ops.model.Container) -> None:
 
     Args:
         container: Synapse container.
+
+    Raises:
+        MASConfigInvalidError: when validation of the MAS config failed.
     """
     command = [MAS_EXECUTABLE_PATH, "config", "check", "-c", MAS_CONFIGURATION_PATH]
-    process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
-    process.wait_output()
+
+    try:
+        process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
+        process.wait_output()
+    except ops.pebble.ExecError as exc:
+        logger.exception("Validation of the MAS config failed.")
+        raise MASConfigInvalidError("Validation of the MAS config failed.") from exc
 
 
 def sync_mas_config(container: ops.model.Container) -> None:
@@ -74,10 +89,18 @@ def sync_mas_config(container: ops.model.Container) -> None:
 
     Args:
         container: Synapse container.
+
+    Raises:
+        MASConfigSyncError: when synchronisation of the MAS config failed.
     """
     command = [MAS_EXECUTABLE_PATH, "config", "sync", "--prune", "-c", MAS_CONFIGURATION_PATH]
-    process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
-    process.wait()
+
+    try:
+        process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
+        process.wait()
+    except ops.pebble.ExecError as exc:
+        logger.exception("Error syncing MAS config with the database.")
+        raise MASConfigSyncError("Error validating MAS configuration.") from exc
 
 
 def register_user(
@@ -116,7 +139,7 @@ def register_user(
         process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
         process.wait_output()
     except ops.pebble.ExecError as exc:
-        logger.error("Error registering new user: %s", exc.stderr)
+        logger.exception("Error registering new user.")
         raise MASRegisterUserFailedError("Error validating MAS configuration.") from exc
 
     return password
@@ -151,7 +174,7 @@ def verify_user_email(
         process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
         process.wait_output()
     except ops.pebble.ExecError as exc:
-        logger.error("Error verifying the user email: %s", exc.stderr)
+        logger.exception("Error verifying the user email.")
         raise MASVerifyUserEmailFailedError("Error verifying the user email.") from exc
 
 
@@ -161,6 +184,9 @@ def deactivate_user(container: ops.model.Container, username: str) -> None:
     Args:
         container: Synapse container.
         username: Username to create the access token.
+
+    Raises:
+        MASDeactivateUserFailedError: when deactivation of the user fails
     """
     command = [
         MAS_EXECUTABLE_PATH,
@@ -172,8 +198,12 @@ def deactivate_user(container: ops.model.Container, username: str) -> None:
         username,
     ]
 
-    process = container.exec(command=command, working_dir=MAS_WORKING_DIR, combine_stderr=True)
-    process.wait_output()
+    try:
+        process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
+        process.wait_output()
+    except ops.pebble.ExecError as exc:
+        logger.error("Error registering new user: %s", exc.stderr)
+        raise MASDeactivateUserFailedError("Error deactivating user.") from exc
 
 
 def generate_mas_config(

--- a/src/auth/mas.py
+++ b/src/auth/mas.py
@@ -41,27 +41,31 @@ MAS_PEBBLE_LAYER = ops.pebble.LayerDict(
 ADMIN_TOKEN_SECRET_LABEL = "admin.token"  # nosec
 
 
+class MASCLIBaseError(Exception):
+    """Base exception for mas-cli related operations."""
+
+
 class MASConfigInvalidError(Exception):
     """Exception raised when validation of the MAS config failed."""
 
 
-class MASConfigSyncError(Exception):
+class MASConfigSyncError(MASCLIBaseError):
     """Exception raised when synchronisation of the MAS config failed."""
 
 
-class MASRegisterUserFailedError(Exception):
+class MASRegisterUserFailedError(MASCLIBaseError):
     """Exception raised when validation of the MAS config failed."""
 
 
-class MASVerifyUserEmailFailedError(Exception):
+class MASVerifyUserEmailFailedError(MASCLIBaseError):
     """Exception raised when validation of the MAS config failed."""
 
 
-class MASDeactivateUserFailedError(Exception):
+class MASDeactivateUserFailedError(MASCLIBaseError):
     """Exception raised when deactivation of a MAS user failed."""
 
 
-class MASGenerateAdminAccessTokenError(Exception):
+class MASGenerateAdminAccessTokenError(MASCLIBaseError):
     """Exception raised when generation of admin token failed."""
 
 
@@ -202,7 +206,7 @@ def deactivate_user(container: ops.model.Container, username: str) -> None:
         process = container.exec(command=command, working_dir=MAS_WORKING_DIR)
         process.wait_output()
     except ops.pebble.ExecError as exc:
-        logger.error("Error registering new user: %s", exc.stderr)
+        logger.exception("Error deactivating user.")
         raise MASDeactivateUserFailedError("Error deactivating user.") from exc
 
 

--- a/src/auth/mas.py
+++ b/src/auth/mas.py
@@ -100,7 +100,7 @@ def sync_mas_config(container: ops.model.Container) -> None:
         process.wait()
     except ops.pebble.ExecError as exc:
         logger.exception("Error syncing MAS config with the database.")
-        raise MASConfigSyncError("Error validating MAS configuration.") from exc
+        raise MASConfigSyncError("Error syncing MAS config with the database.") from exc
 
 
 def register_user(
@@ -140,7 +140,7 @@ def register_user(
         process.wait_output()
     except ops.pebble.ExecError as exc:
         logger.exception("Error registering new user.")
-        raise MASRegisterUserFailedError("Error validating MAS configuration.") from exc
+        raise MASRegisterUserFailedError("Error registering new user.") from exc
 
     return password
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ from ops.charm import ActionEvent, RelationDepartedEvent
 import pebble
 import synapse
 from auth.mas import (
+    MASDeactivateUserFailedError,
     MASRegisterUserFailedError,
     MASVerifyUserEmailFailedError,
     deactivate_user,
@@ -537,7 +538,6 @@ class SynapseCharm(CharmBaseWithState):
         results = {"verify-user-email": True}
         event.set_results(results)
 
-    @validate_charm_state
     def _on_anonymize_user_action(self, event: ActionEvent) -> None:
         """Anonymize user and report action result.
 
@@ -551,7 +551,7 @@ class SynapseCharm(CharmBaseWithState):
 
         try:
             deactivate_user(container=container, username=event.params["username"])
-        except ops.pebble.ExecError as exc:
+        except MASDeactivateUserFailedError as exc:
             logger.exception("Error deactivating user.")
             event.fail(str(exc))
 

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -104,7 +104,6 @@ class SynapseDatabaseObserver(DatabaseObserver):
         """Handle database created events."""
         charm = self.get_charm()
         charm_state = charm.build_charm_state()
-        mas_configuration = MASConfiguration.from_charm(charm)
         self.model.unit.status = ops.MaintenanceStatus("Preparing the database")
         # In case of psycopg2.Error, Juju will set ErrorStatus
         # See discussion here:
@@ -112,4 +111,6 @@ class SynapseDatabaseObserver(DatabaseObserver):
         datasource = self.get_relation_as_datasource()
         db_client = DatabaseClient(datasource=datasource)
         db_client.prepare()
+
+        mas_configuration = MASConfiguration.from_charm(charm)
         charm.reconcile(charm_state, mas_configuration)

--- a/src/state/validation.py
+++ b/src/state/validation.py
@@ -9,10 +9,15 @@ from abc import ABC, abstractmethod
 
 import ops
 
-from state.mas import MASContextNotSetError
+from auth.mas import MASCLIBaseError
+from state.mas import (
+    MASConfiguration,
+    MASContextNotSetError,
+    MASDatasourceInvalidError,
+    MASDatasourceMissingError,
+)
 
 from .charm_state import CharmConfigInvalidError, CharmState
-from .mas import MASConfiguration, MASDatasourceInvalidError, MASDatasourceMissingError
 
 logger = logging.getLogger(__name__)
 
@@ -94,10 +99,7 @@ def validate_charm_state(  # pylint: disable=protected-access
 
         try:
             return method(instance, event)
-        except (
-            CharmConfigInvalidError,
-            MASDatasourceMissingError,
-        ) as exc:
+        except (CharmConfigInvalidError, MASDatasourceMissingError, MASCLIBaseError) as exc:
             logger.exception("Error initializing charm state.")
             # There are two main types of events, Hooks and Actions.
             # Each one of them should be treated differently.


### PR DESCRIPTION
This PR adds missing commits from https://github.com/canonical/synapse-operator/pull/620

- Add missing custom exception wrapping `pebble.ExecError` for `mas-cli` commands 
- Update docs about mjolnir
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
