### PR TITLE
Force getting last secret revision in matrix-auth ISD-2913

### DIFF
--- a/lib/charms/synapse/v1/matrix_auth.py
+++ b/lib/charms/synapse/v1/matrix_auth.py
@@ -67,7 +67,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 4
 
 # pylint: disable=wrong-import-position
 import json
@@ -195,7 +195,7 @@ class MatrixAuthProviderData(BaseModel):
             return None
         try:
             secret = model.get_secret(id=shared_secret_id)
-            password = secret.get_content().get(SHARED_SECRET_CONTENT_LABEL)
+            password = secret.get_content(refresh=True).get(SHARED_SECRET_CONTENT_LABEL)
             if not password:
                 return None
             return SecretStr(password)
@@ -274,7 +274,7 @@ class MatrixAuthRequirerData(BaseModel):
                 secret = model.get_secret(label=ENCRYPTION_KEY_SECRET_LABEL)
             else:
                 secret = model.get_secret(id=encryption_key_secret_id)
-            encryption_key = secret.get_content().get(ENCRYPTION_KEY_SECRET_CONTENT_LABEL)
+            encryption_key = secret.get_content(refresh=True).get(ENCRYPTION_KEY_SECRET_CONTENT_LABEL)
             if not encryption_key:
                 return None
             return encryption_key.encode('utf-8')


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

While testing IRC Bridge + Synapse, I noticed that IRC Bridge was not getting the latest secret version, throwing an error while encrypting/decrypting content.

This PR changes the behavior to always get the latest content instead.

Reference:
https://ops.readthedocs.io/en/latest/howto/manage-secrets.html#start-tracking-a-different-secret-revision

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

Changes matrix-auth library.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
