### PR TITLE
Prevent updating matrix-auth data more than once (#670)

### DIFF
--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -70,7 +70,7 @@ E = typing.TypeVar("E", bound=ops.EventBase)
 
 
 def inject_charm_state(  # pylint: disable=protected-access
-    method: typing.Callable[[C, E, "CharmState"], None]
+    method: typing.Callable[[C, E, "CharmState"], None],
 ) -> typing.Callable[[C, E], None]:
     """Create a decorator that injects the argument charm_state to an observer hook.
 

--- a/src/matrix_auth_observer.py
+++ b/src/matrix_auth_observer.py
@@ -60,8 +60,6 @@ class MatrixAuthObserver(Object):
             if not relation.units:
                 return
             provider_data = self._get_matrix_auth_provider_data(charm_state)
-            if self._matrix_auth_relation_updated(relation, provider_data):
-                return
             self.matrix_auth.update_relation_data(relation, provider_data)
 
     def get_requirer_registration_secrets(self) -> Optional[List]:
@@ -122,30 +120,6 @@ class MatrixAuthObserver(Object):
         container = self._charm.unit.get_container(synapse.SYNAPSE_CONTAINER_NAME)
         shared_secret = synapse.get_registration_shared_secret(container=container)
         return MatrixAuthProviderData(homeserver=homeserver, shared_secret=shared_secret)
-
-    def _matrix_auth_relation_updated(
-        self, relation: ops.Relation, provider_data: MatrixAuthProviderData
-    ) -> bool:
-        """Compare current information with the one in the relation.
-
-        This check is done to prevent triggering relation-changed.
-
-        Args:
-            relation: The matrix-auth relation.
-            provider_data: current Synapse configuration as MatrixAuthProviderData.
-
-        Returns:
-            True if current configuration and relation data are the same.
-        """
-        relation_homeserver = relation.data[self._charm.app].get("homeserver", "")
-        relation_shared_secret = relation.data[self._charm.app].get("shared_secret", "")
-        if (
-            provider_data.homeserver != relation_homeserver
-            or provider_data.shared_secret != relation_shared_secret
-        ):
-            logger.info("matrix-auth relation ID %s is outdated and will be updated", relation.id)
-            return False
-        return True
 
     @inject_charm_state
     def _on_matrix_auth_relation_changed(self, _: ops.EventBase, charm_state: CharmState) -> None:

--- a/tests/unit/test_matrix_auth_integration.py
+++ b/tests/unit/test_matrix_auth_integration.py
@@ -5,11 +5,16 @@
 
 # pylint: disable=protected-access
 
+import logging
 from unittest.mock import ANY, MagicMock
 
 import pytest
 import yaml
-from charms.synapse.v1.matrix_auth import MatrixAuthRequirerData, encrypt_string
+from charms.synapse.v1.matrix_auth import (
+    MatrixAuthProviderData,
+    MatrixAuthRequirerData,
+    encrypt_string,
+)
 from ops.testing import Harness
 from pydantic import SecretStr
 
@@ -45,6 +50,40 @@ def test_matrix_auth_update_success(harness: Harness, monkeypatch: pytest.Monkey
     update_relation_data.assert_called_with(relation, ANY)
 
     assert update_relation_data.call_args[0][1].homeserver == f"https://{TEST_SERVER_NAME}"
+
+
+def test_matrix_auth_update_only_once(harness: Harness, monkeypatch: pytest.MonkeyPatch, caplog):
+    """
+    arrange: start the Synapse charm.
+    act: integrate via matrix-auth.
+    assert: update_relation_data is called and homeserver has same value as
+        server_name.
+    """
+    harness.update_config({"server_name": TEST_SERVER_NAME})
+    harness.set_can_connect(synapse.SYNAPSE_CONTAINER_NAME, True)
+    harness.set_leader(True)
+    harness.begin()
+    monkeypatch.setattr(
+        MatrixAuthProviderData, "get_shared_secret", MagicMock(return_value="shared-secret")
+    )
+    monkeypatch.setattr(
+        synapse, "get_registration_shared_secret", MagicMock(return_value="shared_secret")
+    )
+    rel_id = harness.add_relation(
+        "matrix-auth",
+        "maubot",
+        app_data={
+            "homeserver": "example.com",
+            "shared_secret_id": "test-secret-id",
+            "encryption_key_secret_id": "test-secret-id",
+        },
+    )
+    harness.add_relation_unit(rel_id, "maubot/0")
+
+    with caplog.at_level(logging.WARNING):
+        harness.charm.on.config_changed.emit()
+
+    assert "Matrix Provider relation data is invalid or empty, updating" not in caplog.text
 
 
 def test_matrix_auth_update_public_baseurl_success(


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Apply fix to track/1 as well.

Approved:
https://github.com/canonical/synapse-operator/pull/670

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
