### PR TITLE
Downgrade boto3 (ISD-2999)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,8 @@ parts:
   charm:
     build-packages:
       - libpq-dev
+      - libssl-dev
+      - pkg-config
     build-snaps:
       - rustup
     override-build: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3 ==1.35.81
+boto3 ==1.35.99
 cosl ==0.0.47
 cryptography ==44.0.0
 deepdiff ==8.0.1

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -154,6 +154,10 @@ parts:
             # fix issue while creating file
             # https://github.com/element-hq/synapse/issues/17882
             pip3 install --break-system-packages --prefix="/install" --force-reinstall -v "Twisted==24.7.0"
+            # fix issue while upload media to s3
+            # boto3 is installed by synapse-s3-storage-provider
+            # https://github.com/boto/boto3/issues/4398
+            pip3 install --break-system-packages --prefix="/install" --force-reinstall -v "boto3==1.35.99"
             cp docker/start.py $CRAFT_PART_INSTALL/
             chmod 755 $CRAFT_PART_INSTALL/start.py
             cp -r docker/conf $CRAFT_PART_INSTALL/


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR downgrades boto3 to prevent error while uploading a media.

The user gets an error and in the logs there is the message "An error occurred (MissingContentLength) when calling the PutObject operation: None".

Issue:
https://github.com/boto/boto3/issues/4398

### Rationale

Fix integration with S3.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
