### PR TITLE
Upgrade synapse to 1.127.1 to fix CVE-2025-30355

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -50,3 +50,6 @@ CVE-2024-24788
 # This should be removed once the following PR is merged.
 # https://github.com/element-hq/synapse/pull/17955
 CVE-2024-52804
+CVE-2025-27152
+CVE-2025-25283
+CVE-2024-52798

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/localstack-installation.sh
+++ b/localstack-installation.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/actions/register_user.py
+++ b/src/actions/register_user.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/admin_access_token.py
+++ b/src/admin_access_token.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/backup.py
+++ b/src/backup.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/backup_observer.py
+++ b/src/backup_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
@@ -70,7 +73,7 @@ E = typing.TypeVar("E", bound=ops.EventBase)
 
 
 def inject_charm_state(  # pylint: disable=protected-access
-    method: typing.Callable[[C, E, "CharmState"], None]
+    method: typing.Callable[[C, E, "CharmState"], None],
 ) -> typing.Callable[[C, E], None]:
     """Create a decorator that injects the argument charm_state to an observer hook.
 

--- a/src/charm_types.py
+++ b/src/charm_types.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/database_client.py
+++ b/src/database_client.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/matrix_auth_observer.py
+++ b/src/matrix_auth_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/media_observer.py
+++ b/src/media_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/mjolnir.py
+++ b/src/mjolnir.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/observability.py
+++ b/src/observability.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/pebble.py
+++ b/src/pebble.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/redis_observer.py
+++ b/src/redis_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/s3_parameters.py
+++ b/src/s3_parameters.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/saml_observer.py
+++ b/src/saml_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/smtp_observer.py
+++ b/src/smtp_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/synapse/__init__.py
+++ b/src/synapse/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/synapse/admin.py
+++ b/src/synapse/admin.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/synapse/api.py
+++ b/src/synapse/api.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/synapse/workload.py
+++ b/src/synapse/workload.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/synapse/workload_configuration.py
+++ b/src/synapse/workload_configuration.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/src/user.py
+++ b/src/user.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/synapse_rock/attributemaps/login_ubuntu.py
+++ b/synapse_rock/attributemaps/login_ubuntu.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -107,10 +107,10 @@ parts:
         plugin: nil
         source: https://github.com/element-hq/synapse/
         source-type: git
-        source-tag: v1.120.0
+        source-tag: v1.127.1
         build-environment:
-          - RUST_VERSION: "1.76.0"
-          - POETRY_VERSION: "1.7.1"
+          - RUST_VERSION: "1.82.0"
+          - POETRY_VERSION: "2.1.1"
         override-build: |
             craftctl default
             export RUSTUP_HOME=/rust
@@ -124,6 +124,7 @@ parts:
             # install synapse requirements
             pip3 install --break-system-packages --root-user-action=ignore "poetry==$POETRY_VERSION"
             cp pyproject.toml poetry.lock /synapse/
+            $CRAFT_PART_INSTALL/usr/local/bin/poetry self add poetry-plugin-export
             $CRAFT_PART_INSTALL/usr/local/bin/poetry export --extras all -o /synapse/requirements.txt
             pip3 install --break-system-packages --prefix="/install" --no-deps --no-warn-script-location -r /synapse/requirements.txt
             #
@@ -153,7 +154,7 @@ parts:
             pip3 install --break-system-packages --prefix="/install" --no-deps --no-warn-script-location /synapse[all];
             # fix issue while creating file
             # https://github.com/element-hq/synapse/issues/17882
-            pip3 install --break-system-packages --prefix="/install" --force-reinstall -v "Twisted==24.7.0"
+            #pip3 install --break-system-packages --prefix="/install" --force-reinstall -v "Twisted==24.7.0"
             cp docker/start.py $CRAFT_PART_INSTALL/
             chmod 755 $CRAFT_PART_INSTALL/start.py
             cp -r docker/conf $CRAFT_PART_INSTALL/

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,2 +1,5 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/test_nginx.py
+++ b/tests/integration/test_nginx.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
@@ -43,10 +46,11 @@ async def test_synapse_scaling_nginx_configured(
     )
     assert ops_test.model
     status = await ops_test.model.get_status()
-    unit = list(status.applications[synapse_app.name].units)[1]
+    application = typing.cast(Application, status.applications[synapse_app.name])
+    unit = list(application.units)[1]
     address = status["applications"][synapse_app.name]["units"][unit]["address"]
 
-    logger.info("Units: %s", list(status.applications[synapse_app.name].units))
+    logger.info("Units: %s", list(application.units))
     logger.info("Requesting %s", f"http://{address}:8008/")
     response_worker = requests.get(
         f"http://{address}:8008/", headers={"Host": synapse_app.name}, timeout=5
@@ -83,7 +87,8 @@ async def test_synapse_scaling_down(
     )
     assert ops_test.model
     status = await ops_test.model.get_status()
-    for unit in list(status.applications[synapse_app.name].units):
+    application = typing.cast(Application, status.applications[synapse_app.name])
+    for unit in list(application.units):
         address = status["applications"][synapse_app.name]["units"][unit]["address"]
         response_worker = requests.get(
             f"http://{address}:8080/", headers={"Host": synapse_app.name}, timeout=5
@@ -99,7 +104,8 @@ async def test_synapse_scaling_down(
     )
     assert ops_test.model
     status = await ops_test.model.get_status()
-    for unit in list(status.applications[synapse_app.name].units):
+    application = typing.cast(Application, status.applications[synapse_app.name])
+    for unit in list(application.units):
         address = status["applications"][synapse_app.name]["units"][unit]["address"]
         response_worker = requests.get(
             f"http://{address}:8080/", headers={"Host": synapse_app.name}, timeout=5

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,2 +1,5 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_admin_access_token.py
+++ b/tests/unit/test_admin_access_token.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_admin_create_user.py
+++ b/tests/unit/test_admin_create_user.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_anonymize_user_action.py
+++ b/tests/unit/test_anonymize_user_action.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_backup_observer.py
+++ b/tests/unit/test_backup_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_charm_scaling.py
+++ b/tests/unit/test_charm_scaling.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_matrix_auth_integration.py
+++ b/tests/unit/test_matrix_auth_integration.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_matrix_plugins_lib.py
+++ b/tests/unit/test_matrix_plugins_lib.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_media_observer.py
+++ b/tests/unit/test_media_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_mjolnir.py
+++ b/tests/unit/test_mjolnir.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_promote_user_admin_action.py
+++ b/tests/unit/test_promote_user_admin_action.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_register_user_action.py
+++ b/tests/unit/test_register_user_action.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_smtp_observer.py
+++ b/tests/unit/test_smtp_observer.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_synapse_api.py
+++ b/tests/unit/test_synapse_api.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+; Copyright 2025 Canonical Ltd.
+; See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 


### PR DESCRIPTION
### Overview

CVE [CVE-2025-30355](https://github.com/element-hq/synapse/security/advisories/GHSA-v56r-hwv5-mxg6) is impacting Synapse up to 1.127.0, this change upgrades synapse to 1.127.1

### Rationale

Fixing a CVE and upgrading the tooling (Poetry and Rust)

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
