### PR TITLE
Increase backgroundDelayMS and add safeMode option to Draupnir

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-05-09
+
+- Add safemode option to Draupnir configuration and increase backgroundDelayMS to 1000.
+
 ### 2025-04-16
 
 - Set room_list_publication_rules as allowing by default. This was changed to blocking starting from Synapse [1.126.0](https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md#room-list-publication-rules-change) version.

--- a/templates/moderation_production.yaml
+++ b/templates/moderation_production.yaml
@@ -9,7 +9,13 @@ automaticallyRedactForReasons:
 - "spam"
 - "advertising"
 protectAllJoinedRooms: false
-backgroundDelayMS: 500
+backgroundDelayMS: 1000
+safeMode:
+#  # The option for entering safe mode when Draupnir fails to start up.
+#  # - "RecoveryOnly" will only start the bot in safe mode when there are recovery options available. This is the default.
+#  # - "Never" will never start the bot in safe mode when Draupnir fails to start normally.
+#  # - "Always" will always start the bot in safe mode when Draupnir fails to start normally.
+  bootOption: Always
 health:
     healthz:
         enabled: true

--- a/templates/moderation_production.yaml
+++ b/templates/moderation_production.yaml
@@ -11,10 +11,10 @@ automaticallyRedactForReasons:
 protectAllJoinedRooms: false
 backgroundDelayMS: 1000
 safeMode:
-#  # The option for entering safe mode when Draupnir fails to start up.
-#  # - "RecoveryOnly" will only start the bot in safe mode when there are recovery options available. This is the default.
-#  # - "Never" will never start the bot in safe mode when Draupnir fails to start normally.
-#  # - "Always" will always start the bot in safe mode when Draupnir fails to start normally.
+# The option for entering safe mode when Draupnir fails to start up.
+# - "RecoveryOnly" will only start the bot in safe mode when there are recovery options available. This is the default.
+# - "Never" will never start the bot in safe mode when Draupnir fails to start normally.
+# - "Always" will always start the bot in safe mode when Draupnir fails to start normally.
   bootOption: Always
 health:
     healthz:

--- a/tests/unit/test_synapse_workload.py
+++ b/tests/unit/test_synapse_workload.py
@@ -745,7 +745,7 @@ def test_generate_moderation_config():
 automaticallyRedactForReasons:
 - spam
 - advertising
-backgroundDelayMS: 500
+backgroundDelayMS: 1000
 dataPath: /data/storage
 displayReports: true
 fasterMembershipChecks: false
@@ -765,6 +765,8 @@ noop: false
 pollReports: false
 protectAllJoinedRooms: false
 rawHomeserverUrl: http://localhost:8080
+safeMode:
+  bootOption: Always
 syncOnStartup: true
 verboseLogging: false
 verifyPermissionsOnStartup: true


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR adds two changes:
- Increase backgroundDelayMS  so Draupnir will wait longer between two consecutive background operations. Preventing impact on Synapse.
- Add a configuration that only exists in Draupnir: "safemode". "Safe mode provides recovery options for some failure modes when Draupnir fails to start."
Without this configuration, if Synapse is not active before Draupnir, the pebble layer fails to start affecting the charm.

Reference:
https://github.com/the-draupnir-project/Draupnir/blob/main/config/default.yaml#L196

### Rationale

Prevent Draupnir from affecting Synapse performance and availability.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
