### PR TITLE
1/edge: Run config-changed logic in upgrade charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -83,6 +83,7 @@ class SynapseCharm(CharmBaseWithState):
         self._observability = Observability(self)
         self._mjolnir = Mjolnir(self, token_service=self.token_service)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.upgrade_charm, self._on_config_changed)
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(
             self.on[synapse.SYNAPSE_PEER_RELATION_NAME].relation_departed,


### PR DESCRIPTION
This avoids situations where doing a juju refresh doesn't update the workload version shown by juju status. Also in general logics in config-changed should also be ran in upgrade-charm.

This PR is for the 1/edge channel.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
