### PR TITLE
Add two env vars to s3 command

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -60,10 +60,12 @@ CVE-2024-53863
 # This should be removed once pebble releases a new version.
 # https://github.com/canonical/pebble/commit/0c134f8e0d80f4bd8f42011279c8f0737b59a673
 CVE-2024-45338
-# Node.js vulnerabilty
+# Node.js vulnerability
 CVE-2024-52798
 CVE-2025-25283
 CVE-2025-27152
 # setuptools and tornado - Should be removed once synapse is bumped to 1.131.0 ( current latest version is 1.130 )
 CVE-2025-47273
 CVE-2025-47287
+# Pebble vulnerability
+CVE-2025-22874

--- a/src/backup.py
+++ b/src/backup.py
@@ -477,6 +477,8 @@ def _get_environment(s3_parameters: S3Parameters) -> Dict[str, str]:
     environment = {
         "AWS_ACCESS_KEY_ID": s3_parameters.access_key,
         "AWS_SECRET_ACCESS_KEY": s3_parameters.secret_key,
+        "AWS_REQUEST_CHECKSUM_CALCULATION": "WHEN_REQUIRED",
+        "AWS_RESPONSE_CHECKSUM_VALIDATION": "WHEN_REQUIRED",
     }
     if s3_parameters.endpoint:
         environment["AWS_ENDPOINT_URL"] = s3_parameters.endpoint


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

The create-backup is failing due the error "upload failed: - to s3://prod-chat-ubuntu-com-k8s-backup/synapse-backup/backup-20250616010002338289 An error occurred (MissingContentLength) when calling the UploadPart operation: Unknown\n""

Trying to downgrade boto didn't work, but after some digging, I found two environment variables that, once set, fix the problem.

### Rationale

Fix create-backup action

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [ ] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
No changelog in this track.