### PR TITLE
Prevent installing deps from synapse-invite-checker

### DIFF
--- a/synapse_rock/rockcraft.yaml
+++ b/synapse_rock/rockcraft.yaml
@@ -148,7 +148,7 @@ parts:
       git clone https://github.com/nbuechner/synapse-invite-checker.git
       cd synapse-invite-checker
       git checkout ab6c8b78d78c4cbf31e1a30981ae45c09285b34a
-      pip3 install --break-system-packages --prefix="/install" --no-warn-script-location -U .
+      pip3 install --break-system-packages --prefix="/install" --no-deps --no-warn-script-location -U .
       cd ..
       #
       # install synapse


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

synapse-invite-checker was upgrading Synapse since it was installed without the parameter "--no-deps".

Thanks @weiiwang01 for finding the issue!

This PR adds the parameter, preventing the installation from changing the version installed by the rock.

### Rationale

Pinning deps.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [ ] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
No need to update changelog.