### PR TITLE
Change boto3 and label for workload-update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,11 +64,6 @@
       "pinDigests": true
     },
     {
-      "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "enabled": false
-    },
-    {
       "matchDatasources": [
           "custom.charmhub"
       ],
@@ -79,6 +74,15 @@
       "matchDatasources": ["terraform-provider"],
       "matchPackageNames": ["juju/juju"],
       "enabled": true
+    },
+	{
+      "matchPackageNames": ["boto3"],
+      "matchUpdateTypes": ["patch"],
+	  "enabled": false
+    },
+	{
+      "matchDatasources": ["github-releases"],
+      "labels": ["workload-update"]
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Synapse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

This PR changes Renovate by:
- Disabling patch PRs for boto3
- Adding label "workload-update" for PRs changing Synapse or MAS versions

Improvement for this PR: group minor updates in a single PR

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [ ] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
