### PR TITLE
Fix ci permission issues

### DIFF
--- a/.github/workflows/auto_update_libs.yaml
+++ b/.github/workflows/auto_update_libs.yaml
@@ -8,4 +8,7 @@ on:
 jobs:
   auto-update-libs:
     uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -6,4 +6,7 @@ on:
 jobs:
   bot_pr_approval:
     uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -9,4 +9,7 @@ on:
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/comment_contributing.yaml
+++ b/.github/workflows/comment_contributing.yaml
@@ -10,4 +10,7 @@ on:
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       pre-run-script: s3-installation.sh

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       channel: 1/edge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
     with:
       self-hosted-runner: false

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -247,18 +247,12 @@ linkcheck_ignore = [
     "https://example.com",
     # SourceForge domains often block linkcheck
     r"https://.*\.sourceforge\.(net|io)/.*",
+    # Canonical domains blocked by Cloudflare DDoS mitigation from outside Canonical's network.
+    # TODO: Remove once Canonical's heightened DDoS protection is lifted.
+    r"https://ubuntu\.com/.*",
+    r"https://microk8s\.io/.*",
+    r"https://multipass\.run/.*",
     ]
-
-# Use a browser-like User-Agent for Canonical domains protected by Cloudflare DDoS mitigation.
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_request_headers
-_browser_ua = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
-}
-linkcheck_request_headers = {
-    r"https://ubuntu\.com/.*": _browser_ua,
-    r"https://microk8s\.io/.*": _browser_ua,
-    r"https://multipass\.run/.*": _browser_ua,
-}
 
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,6 +249,17 @@ linkcheck_ignore = [
     r"https://.*\.sourceforge\.(net|io)/.*",
     ]
 
+# Use a browser-like User-Agent for Canonical domains protected by Cloudflare DDoS mitigation.
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_request_headers
+_browser_ua = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+}
+linkcheck_request_headers = {
+    r"https://ubuntu\.com/.*": _browser_ua,
+    r"https://microk8s\.io/.*": _browser_ua,
+    r"https://multipass\.run/.*": _browser_ua,
+}
+
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,9 +249,10 @@ linkcheck_ignore = [
     r"https://.*\.sourceforge\.(net|io)/.*",
     # Canonical domains blocked by Cloudflare DDoS mitigation from outside Canonical's network.
     # TODO: Remove once Canonical's heightened DDoS protection is lifted.
-    r"https://ubuntu\.com/.*",
-    r"https://microk8s\.io/.*",
-    r"https://multipass\.run/.*",
+    r"https://ubuntu\.com.*",
+    r"https://microk8s\.io.*",
+    r"https://multipass\.run.*",
+    r"https://juju\.is.*",
     ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3 ==1.42.4
 cosl ==1.4.0
 cryptography ==46.0.4
-deepdiff ==8.6.2
+deepdiff ==8.6.1
 jinja2 ==3.1.6
 jsonschema ==4.26.0
 ops ==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3 ==1.42.4
 cosl ==1.4.0
 cryptography ==46.0.4
-deepdiff ==8.6.1
+deepdiff ==8.6.2
 jinja2 ==3.1.6
 jsonschema ==4.26.0
 ops ==3.5.1


### PR DESCRIPTION
#### What this PR does

Updated the repo's workflows to explicitely set requires read permissions following the change to default `read-only` permissions on GITHUB_TOKENS within the canonical org.

Also updating the config for the docs linkchecker, which was failing checks on canonical-based documentation domains. The assumption here being that security measures applied in the last weeks, such as placing those domains behind Cloudflare, are preventing the linkchecker from reaching those websites.

