### PR TITLE
fix: align cryptography version and fix Renovate group config

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -31,4 +31,4 @@ parts:
       craftctl default
     charm-binary-python-packages:
     - psycopg2-binary==2.9.12
-    - cryptography==46.0.4
+    - cryptography==48.0.0

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,7 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Track charm-binary-python-packages versions in charmcraft.yaml",
       "fileMatch": ["(^|/)charmcraft\\.yaml$"],
       "matchStrings": ["- (?<depName>[a-z0-9_-]+)==(?<currentValue>[^\\s]+)"],
       "datasourceTemplate": "pypi"
@@ -42,9 +43,10 @@
   ],
   "packageRules": [
     {
-      "description": "Group charmcraft.yaml and requirements.txt updates for charm-binary-python-packages so both files are bumped atomically.",
+      "description": "Group charmcraft.yaml and requirements.txt updates for charm-binary-python-packages so both files are bumped atomically in one PR.",
       "matchPackageNames": ["psycopg2-binary", "cryptography"],
-      "groupName": "charm-binary-python-packages"
+      "groupName": "charm-binary-python-packages",
+      "separateMajorMinor": false
     },
     {
       "enabled": true,


### PR DESCRIPTION
## Problem

Two bugs introduced when the `charm-binary-python-packages` Renovate tracking was added:

1. **Version mismatch**: `charmcraft.yaml` was pinned to `cryptography==46.0.4` while `requirements.txt` was already at `==48.0.0`. This caused Renovate to open two PRs (#1187, #1188) that only touched `charmcraft.yaml`, without updating `requirements.txt`.

2. **Missing `separateMajorMinor: false`**: Without this, Renovate splits grouped updates into two separate PRs (one for minor, one for major), defeating the purpose of the group.

## Fix

- Align `charmcraft.yaml` to `cryptography==48.0.0` to match `requirements.txt`
- Add `separateMajorMinor: false` to the `charm-binary-python-packages` package rule so future updates always produce a single PR

Once merged, PRs #1187 and #1188 will be auto-closed by Renovate as stale.