### PR TITLE
fix(ci): grant permissions for auto_update_libs reusable workflow

### DIFF
--- a/.github/workflows/auto_update_libs.yaml
+++ b/.github/workflows/auto_update_libs.yaml
@@ -11,4 +11,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
## Summary
- add `id-token: write` in `.github/workflows/auto_update_libs.yaml`

## Why
The reusable workflow declares `id-token: write`; callers must grant it explicitly for startup permission checks to pass under read-only default workflow permissions.